### PR TITLE
Add piggieback middleware to repl

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -33,7 +33,8 @@
                                         :optimizations :none
                                         :pretty-print  true}}}}
 
-  :profiles {:dev {:repl-options {:init-ns {{name}}.server}
+  :profiles {:dev {:repl-options {:init-ns {{name}}.server
+                                  :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
                    :plugins [[lein-figwheel "0.1.4-SNAPSHOT"]]
                    :figwheel {:http-server-root "public"
                               :port 3449 }


### PR DESCRIPTION
This fixes the error that occurs when running `(browser repl)`

```
IllegalStateException Can't change/establish root binding of: *cljs-repl-options* with set  clojure.lang.Var.set
```
