### PR TITLE
add release cljsbuild

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -32,7 +32,12 @@
                                         :preamble      ["react/react.min.js"]
                                         :externs       ["react/externs/react.js"]
                                         :optimizations :none
-                                        :pretty-print  true}}}}
+                                        :pretty-print  true}}
+                       :release {:source-paths ["src/cljs"]
+                              :compiler {:output-to     "target/app.js"
+                                         :preamble      ["react/react.min.js"]
+                                         :externs       ["react/externs/react.js"]
+                                         :optimizations :advanced}}}}
 
   :profiles {:dev {:repl-options {:init-ns {{name}}.server
                                   :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}


### PR DESCRIPTION
because sometimes I don't want an uberjar, I just want a single js file I can slap on an existing website
