### PR TITLE
move env var handling into profiles.clj

### DIFF
--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -54,6 +54,8 @@
     (->files data
              ["project.clj"
               (render "project.clj" data)]
+             ["profiles.clj"
+              (render "profiles.clj" data)]
              ["resources/index.html"
               (render "resources/index.html" data)]
              ["resources/public/css/style.css"

--- a/src/leiningen/new/chestnut/.gitignore
+++ b/src/leiningen/new/chestnut/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 /resources/public/js
 /out
 /.repl
+profiles.clj

--- a/src/leiningen/new/chestnut/profiles.clj
+++ b/src/leiningen/new/chestnut/profiles.clj
@@ -1,0 +1,1 @@
+{:dev {:env {:is-dev true}}}

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -40,7 +40,6 @@
                    :figwheel {:http-server-root "public"
                               :port 3449
                               :css-dirs ["resources/public/css"]}
-                   :env {:is-dev true}
                    :cljsbuild {:builds {:app {:source-paths ["env/dev/cljs"]}}}}
 
              :uberjar {:hooks [leiningen.cljsbuild]


### PR DESCRIPTION
I've just noticed a problem trying to set some custom environment variables in a `profiles.clj` in the project dir. As soon as you specify an `:env` key in there the `:is-dev` env var is dropped. I.e. the contents of the `:env` key in my `profiles.clj` **replace** the contents of the `:env` key in the `project.clj`. 

There are two things that could be done:
1. Put the `:is-dev` key into `profiles.clj`, commit once, add to `.gitignore`
2. Setup two profiles `:project/dev` and `:profiles/dev` that are then aliased to `:dev` (see more below)

**I'm in favour of the first option, as it's much simpler and intuitive to newcomers, PR attached.**

Some IRC conversations I had about this as I was surprised myself:

```
[12:12:15]  <clgv>  martinklepsch: profiles are merged by leiningen
[12:12:38]  <clgv>  martinklepsch: you can check with "lein pprint"
[12:14:38]  <martinklepsch> the documentation said it'd merge recursively, that's why I was expecting both keys to be in the :env map
[12:17:18]  <weavejester>   Lein profiles are merged recursively, though if you have the same profile declared in two locations, only one version is used.
[12:21:53]  <clgv>  weavejester: really? that's unexpected when everything else is merged and ^:replace metadata can be used as well
[12:22:16]  <weavejester>   clgv: Yeah, it’s a bit of a gotcha
[12:22:34]  <weavejester>   clgv: For example, if you have a :dev profile in your project.clj and a local profiles.clj
[12:22:58]  <clgv>  weavejester: indeed
[12:22:59]  <weavejester>   So I tend to have :local/dev and :repo/dev profiles
[12:23:21]  <clgv>  weavejester: and then aliases in the project.clj?
[12:23:21]  <weavejester>   Though maybe I should call them :profiles/dev and :project/dev
[12:23:35]  <weavejester>   Yeah, :dev [:repo/dev :local/dev]
```

```
[12:36:52]  <martinklepsch> weavejester: in a project.clj with :env {:is-dev true} it wouldn't make much sense to go the :profiles/dev :project/dev route, right?
[12:37:23]  <martinklepsch> you could just commit profiles.clj with that single entry and add it to .gitignore afterwards
[12:39:23]  <weavejester>   martinklepsch: Well, you really only need to go down the :profiles/dev route if (a) you want to have local overrides to your project that aren’t in source control, and (b) you already have a :dev profile you don’t want to overwrite, but merge into
[12:41:32]  <martinklepsch> ok, thanks
```
