### PR TITLE
Prevent weasel from undoing the enable-console-print

### DIFF
--- a/src/leiningen/new/chestnut/env/dev/cljs/chestnut/dev.cljs
+++ b/src/leiningen/new/chestnut/env/dev/cljs/chestnut/dev.cljs
@@ -10,6 +10,6 @@
   :websocket-url "ws://localhost:3449/figwheel-ws"
   :jsload-callback (fn [] (core/main)))
 
-(weasel/connect "ws://localhost:9001" :verbose true)
+(weasel/connect "ws://localhost:9001" :verbose true :print #{:repl :console})
 
 (core/main)


### PR DESCRIPTION
Currently, when there's a browser REPL available, the `(enable-console-print!)` is immediately undone when the page loads.

Weasel supports this scenario. See: https://github.com/tomjakubowski/weasel/blob/master/src/cljs/weasel/repl.cljs#L50

With this change, it logs output to the console and to the REPL.
