### PR TITLE
Fix --cljx, remove {{sanitize}} in path

### DIFF
--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -134,7 +134,7 @@
           (less? opts) (conj "src/less/style.less")
           (sass? opts) (conj "src/scss/style.scss")
           (not (or (less? opts) (sass? opts))) (conj "resources/public/css/style.css")
-          (cljx? opts) (conj "src/cljx/{{sanitized}}/core.cljx")
+          (cljx? opts) (conj "src/cljx/chestnut/core.cljx")
           (speclj? opts) (conj "bin/speclj"
                              "spec/clj/chestnut/server_spec.clj"
                              "spec/cljs/chestnut/core_spec.cljs"


### PR DESCRIPTION
`lein new chestnut foo -- --cljx` failed after recent changes.
