### PR TITLE
Make is-dev? a boolean value, rather than function

### DIFF
--- a/src/leiningen/new/chestnut/env/prod/clj/chestnut/dev.clj
+++ b/src/leiningen/new/chestnut/env/prod/clj/chestnut/dev.clj
@@ -6,7 +6,7 @@
                           "You likely have compiled class files lying around from an uberjar build. "
                           "Remove the target/ directory and try again."))))
 
-(defn is-dev? [] false)
+(def is-dev? false)
 (def inject-devmode-html identity)
 (defn browser-repl []
   (throw (Exception. "Browser connected REPL is not available in prod mode")))


### PR DESCRIPTION
In the dev source path's `{{project-ns}}.dev` ns, the `is-dev?` var is a boolean, but in the production source's `{{project-ns.dev}}` ns, it was a function. 