### PR TITLE
Update ClojureScript dependency to 0.0-2644.

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -9,7 +9,7 @@
   :test-paths ["spec/clj"]
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2496" :scope "provided"]
+                 [org.clojure/clojurescript "0.0-2644" :scope "provided"]
                  [ring "1.3.2"]
                  [ring/ring-defaults "0.1.2"]
                  [compojure "1.3.1"]


### PR DESCRIPTION
This version contains new cljs.repl.node. You can start a ClojureScript Node.js REPL by using a script such as the example provided by the Mies Leiningen template: https://github.com/swannodette/mies/blob/master/src/leiningen/new/mies/compile_cljsc