### PR TITLE
Removed cljsbuild externs for React.js.

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -29,7 +29,6 @@
                                         :output-dir    "resources/public/js/out"
                                         :source-map    "resources/public/js/out.js.map"
                                         :preamble      ["react/react.min.js"]
-                                        :externs       ["react/externs/react.js"]
                                         :optimizations :none
                                         :pretty-print  true}}}}{{#less?}}
 


### PR DESCRIPTION
Google Closure returns an error indicating duplicate externs file when using :optimizations advanced, this is due to the externs being already included by Om in deps.clj. David Nolen has explained it in this mail thread https://www.mail-archive.com/clojurescript@googlegroups.com/msg03826.html