### PR TITLE
Revert ClojureScript version to latest that works with Om 0.8.0-rc1.

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -9,7 +9,7 @@
   :test-paths ["spec/clj"]
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2644" :scope "provided"]
+                 [org.clojure/clojurescript "0.0-2511" :scope "provided"]
                  [ring "1.3.2"]
                  [ring/ring-defaults "0.1.2"]
                  [compojure "1.3.1"]


### PR DESCRIPTION
I wasn't able to get the 0.0-2644 version of ClojureScript to work with 0.8.0-rc1 (and/or the SNAPSHOT version of Chestnut). I reverted the ClojureScript version to the one included with Om 0.8.0-rc1, which his 2511 (the version included in this change).

For the record, the error I got when starting the "browser-repl" (weasel + piggieback), via the Lein REPL, is listed here:
```` clojure
server=> (browser-repl)
<< started Weasel server on ws://0.0.0.0:9001 >>
Type `:cljs/quit` to stop the ClojureScript REPL

ArityException Wrong number of args (2) passed to: repl/fn--5122/self--5128  clojure.lang.AFn.throwArity (AFn.java:429)
````