### PR TITLE
Stub start-less and start-sass in prod env

### DIFF
--- a/src/leiningen/new/chestnut/env/prod/clj/chestnut/dev.clj
+++ b/src/leiningen/new/chestnut/env/prod/clj/chestnut/dev.clj
@@ -12,3 +12,11 @@
   (throw (Exception. "Browser connected REPL is not available in prod mode")))
 (defn start-figwheel []
   (throw (Exception. "Figwheel is not available in prod mode")))
+{{#less?}}
+(defn start-less []
+  (throw (Exception. "less is not available in prod mode")))
+{{/less?}}
+{{#sass?}}
+(defn start-sass []
+  (throw (Exception. "sass is not available in prod mode")))
+{{/sass?}}


### PR DESCRIPTION
Fixes #72 

In a wider sense, I'm wondering if it might be better to move all dev init logic out of `server`.  Perhaps, `env/dev/{{name}}/dev-server.clj` contains the auto-reload init code and its own `run` function.  Thoughts?