### PR TITLE
update clojurescript, Piggieback and weasel deps

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -9,7 +9,7 @@
   :test-paths ["spec/clj"]
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2511" :scope "provided"]
+                 [org.clojure/clojurescript "0.0-2913" :scope "provided"]
                  [ring "1.3.2"]
                  [ring/ring-defaults "0.1.3"]
                  [compojure "1.3.1"]
@@ -53,8 +53,8 @@
 
                    :dependencies [[figwheel "0.2.1-SNAPSHOT"]
                                   [figwheel-sidecar "0.2.1-SNAPSHOT"]
-                                  [com.cemerick/piggieback "0.1.3"]
-                                  [weasel "0.4.2"]{{{project-dev-deps}}}]
+                                  [com.cemerick/piggieback "0.1.5"]
+                                  [weasel "0.6.0"]]
 
                    :repl-options {:init-ns {{project-ns}}.server
                                   :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl{{{nrepl-middleware}}}]}


### PR DESCRIPTION
I could not get the repl, cider-jack-in or anything working with the versions added to project.clj.  I have updated my generated project with the changes I made to ```src/leiningen/new/chestnut/project.clj```.

After I made these changes and ran ```lein chestnut new new_project```, the generated project did not have the new updated dependencies in the generated project, should I have bumped the version number of the project or could you let me know what I have to do?  Running ```lien install``` did not seem to override the existing project.