### PR TITLE
Remove react.js injection in dev html

### DIFF
--- a/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
+++ b/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
@@ -14,7 +14,6 @@
   (comp
      (set-attr :class "is-dev")
      (prepend (html [:script {:type "text/javascript" :src "/js/out/goog/base.js"}]))
-     (prepend (html [:script {:type "text/javascript" :src "/react/react.js"}]))
      (append  (html [:script {:type "text/javascript"} "goog.require('{{project-goog-module}}.main')"]))))
 
 (defn browser-repl []


### PR DESCRIPTION
Now Om depends on cljsjs.react, it gets compiled into app.js. No need to include the script separately.

Without this change, in dev, `react.js` is requested, but the response is the `index.html` html, thus resulting in `Uncaught SyntaxError: Unexpected token <` with the browser attempting to evaluate the html as js.

See: https://github.com/omcljs/om/commit/b549554964fe5b53189222e97e77fc2db34aebd6#diff-0fff143854a4f5c0469a3819b978a483