### PR TITLE
Set test-paths correctly for Speclj and clojure.test

### DIFF
--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -109,7 +109,8 @@
 
    ;; testing features
    :speclj?              (fn [block] (if (speclj? opts) (str "\n" block) ""))
-   :test-src-path        (if (speclj? opts) "\"spec/cljs\"" "\"test/cljs\"")
+   :clj-test-src-path    (if (speclj? opts) "\"spec/clj\"" "\"test/clj\"")
+   :cljs-test-src-path   (if (speclj? opts) "\"spec/cljs\"" "\"test/cljs\"")
    :test-command-name    (if (speclj? opts) "\"spec\"" "\"test\"")
    :test-command         (if (speclj? opts)
                            "[\"phantomjs\" \"bin/speclj\" \"resources/public/js/app_test.js\"]"

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -6,7 +6,7 @@
 
   :source-paths ["src/clj"{{{project-source-paths}}}]
 
-  :test-paths ["spec/clj"]
+  :test-paths [{{{clj-test-src-path}}}]
 
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-3058" :scope "provided"]
@@ -69,7 +69,7 @@
 
                    :cljsbuild {:test-commands { {{{test-command-name}}} {{{test-command}}} }
                                :builds {:app {:source-paths ["env/dev/cljs"]}
-                                        :test {:source-paths ["src/cljs" {{{test-src-path}}}]
+                                        :test {:source-paths ["src/cljs" {{{cljs-test-src-path}}}]
                                                :compiler {:output-to     "resources/public/js/app_test.js"
                                                           :output-dir    "resources/public/js/test"
                                                           :source-map    "resources/public/js/test.js.map"


### PR DESCRIPTION
Fixes #116.

Added a clj-test-src-path variable to the data map.  Renamed the
clojurescript test-src-path to be prefixed with 'cljs-'.