### PR TITLE
Update project.clj to fix #122

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -63,7 +63,8 @@
 
                    :figwheel {:http-server-root "public"
                               :server-port 3449
-                              :css-dirs ["resources/public/css"]}
+                              :css-dirs ["resources/public/css"]
+                              :ring-handler {{project-ns}}.server/http-handler}
 
                    :env {:is-dev true}
 


### PR DESCRIPTION
Adds the `:ring-handler` key to the figwheel configuration. See #122.