### PR TITLE
Fixes missing sourcemaps when using figwheel.

### DIFF
--- a/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
+++ b/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
@@ -28,7 +28,8 @@
                                      :output-dir           "resources/public/js/out"
                                      :source-map           "resources/public/js/out.js.map"
                                      :source-map-timestamp true
-                                     :preamble             ["react/react.min.js"]}}]
+                                     :preamble             ["react/react.min.js"]
+                                     :optimizations        :whitespace}}]
                 :figwheel-server server}]
     (fig-auto/autobuild* config)))
 {{#less?}}


### PR DESCRIPTION
Added whitespace optimizations to figwheel start so that source maps are generated correctly. Without this addition, using `(run)` from REPL does not generate source maps.