### PR TITLE
Out of the box, source maps are not generated when using figwheel.

### DIFF
--- a/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
+++ b/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
@@ -26,7 +26,8 @@
                           :source-paths ["src/cljs" "env/dev/cljs"]
                           :compiler {:output-to            "resources/public/js/app.js"
                                      :output-dir           "resources/public/js/out"
-                                     :source-map           "resources/public/js/out.js.map"
+                                     :source-map           true
+				     :optimizations        :none
                                      :source-map-timestamp true
                                      :preamble             ["react/react.min.js"]
                                      :optimizations        :whitespace}}]

--- a/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
+++ b/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
@@ -28,7 +28,8 @@
                                      :output-dir           "resources/public/js/out"
                                      :source-map           "resources/public/js/out.js.map"
                                      :source-map-timestamp true
-                                     :preamble             ["react/react.min.js"]}}]
+                                     :preamble             ["react/react.min.js"]
+                                     :optimizations        :whitespace}}]
                 :figwheel-server server}]
     (fig-auto/autobuild* config)))
 {{#less?}}

--- a/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
+++ b/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
@@ -27,10 +27,9 @@
                           :compiler {:output-to            "resources/public/js/app.js"
                                      :output-dir           "resources/public/js/out"
                                      :source-map           true
-				     :optimizations        :none
+                                     :optimizations        :none
                                      :source-map-timestamp true
-                                     :preamble             ["react/react.min.js"]
-                                     :optimizations        :whitespace}}]
+                                     :preamble             ["react/react.min.js"]}}]
                 :figwheel-server server}]
     (fig-auto/autobuild* config)))
 {{#less?}}


### PR DESCRIPTION
Using `(run)` from the REPL does not result in source maps being generated. This change to the profile fixes the issue.