### PR TITLE
Out of the box, source maps are not generated when using figwheel. (#2)

### DIFF
--- a/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
+++ b/src/leiningen/new/chestnut/env/dev/clj/chestnut/dev.clj
@@ -26,7 +26,8 @@
                           :source-paths ["src/cljs" "env/dev/cljs"]
                           :compiler {:output-to            "resources/public/js/app.js"
                                      :output-dir           "resources/public/js/out"
-                                     :source-map           "resources/public/js/out.js.map"
+                                     :source-map           true
+                                     :optimizations        :none
                                      :source-map-timestamp true
                                      :preamble             ["react/react.min.js"]}}]
                 :figwheel-server server}]


### PR DESCRIPTION
Using (run) from the REPL does not result in source maps being generated. This change to the profile fixes the issue.

Sorry for a fresh PR, I am not sure how to (or even if you can) squash commits once it's been PR'd.