### PR TITLE
apply str to (page)

### DIFF
--- a/src/leiningen/new/chestnut/src/clj/chestnut/server.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/server.clj
@@ -16,7 +16,7 @@
 (defroutes routes
   (resources "/")
   (resources "/react" {:root "react"})
-  (GET "/*" req (page)))
+  (GET "/*" req (apply str (page))))
 
 (def http-handler
   (if is-dev?


### PR DESCRIPTION
From https://github.com/cgrand/enlive/wiki/Getting-started#performing-the-transformation:

> To perform the transformation, call the defined template function (passing parameters if any)…

```clojure
x=> (apply str (t1))
"<html>wargh</html>"
```
> Why did we use (apply str… ?

```clojure
x=> (t1)
("<html>" "wargh" "</html>")
```

> Just calling the function performs the transformation, but returns a list of tokens which need to be concatenated into the final output string.

On my branch with these routes:

```clojure
  (GET "/noapply" req (page))
  (GET "/apply" req (apply str (page)))
```

`applys`'s response is a string:

```clojure
{:status 200,
 :headers {"Content-Type" "text/html; charset=utf-8"},
 :body
 "<!DOCTYPE html>\n<html>\n  <head>\n    <link type=\"text/css\" rel=\"stylesheet\" href=\"css/style.css\" />\n  </head>\n  <body class=\"is-dev\"><script type=\"text/javascript\" src=\"/js/out/goog/base.js\"></script>\n    <div id=\"app\"></div>\n    <script type=\"text/javascript\" src=\"/js/app.js\"></script>\n  <script type=\"text/javascript\">goog.require('budget_om.main')</script></body>\n\n</html>"}
```

`noapply`'s response is a list:

```clojure
{:status 200,
 :headers {"Content-Type" "text/html; charset=utf-8"},
 :body
 ("<!DOCTYPE html>\n"
  "<"
  "html"
  ">"
  "\n  "
  "<"
  "head"
  ">"
  "\n    "
  "<"
  "link"
  " "
  "type"
  "=\""
  "text/css"
  "\""
  " "
  "rel"
  "=\""
  "stylesheet"
  "\""
  " "
  "href"
  "=\""
  "css/style.css"
  "\""
  " />"
  "\n  "
  "</"
  "head"
  ">"
  "\n  "
  "<"
  "body"
  " "
  "class"
  "=\""
  "is-dev"
  "\""
  ">"
  "<"
  "script"
  " "
  "type"
  "=\""
  "text/javascript"
  "\""
  " "
  "src"
  "=\""
  "/js/out/goog/base.js"
  "\""
  "></"
  "script"
  ">"
  "\n    "
  "<"
  "div"
  " "
  "id"
  "=\""
  "app"
  "\""
  "></"
  "div"
  ">"
  "\n    "
  "<"
  "script"
  " "
  "type"
  "=\""
  "text/javascript"
  "\""
  " "
  "src"
  "=\""
  "/js/app.js"
  "\""
  "></"
  "script"
  ">"
  "\n  "
  "<"
  "script"
  " "
  "type"
  "=\""
  "text/javascript"
  "\""
  ">"
  "goog.require('budget_om.main')"
  "</"
  "script"
  ">"
  "</"
  "body"
  ">"
  "\n\n"
  "</"
  "html"
  ">")}
```

This was causing this error `java.lang.ClassCastException: clojure.lang.PersistentVector$ChunkedSeq cannot be cast to java.lang.String` when I tried to further transform the `:body` of the response via a handler.