### PR TITLE
change versions of clojurescript and om to the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ reports and pull requests are very welcome.
 ## Changelog
 
 ### Master
+* Version upgrades: clojurescript: 1.7.122 => 1.7.145, om: 0.9.0 => 1.0.0-alpha14
 * Fix allowing projects to have - in their names.
 * Fix allowing groupID/artifactID naming convention.
 * Fix "No such namespace" when using om via the REPL.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ reports and pull requests are very welcome.
 ## Changelog
 
 ### Master
-* Version upgrades: clojurescript: 1.7.122 => 1.7.145, om: 0.9.0 => 1.0.0-alpha14
+* Version upgrades: clojurescript: 1.7.122 => 1.7.145, om: 0.9.0 => 1.0.0-alpha15, tools.nrepl => 0.2.12, figwheel => 0.4.1, figwheel-sidecar => 0.4.1, lein-figwheel => 0.4.1
 * Fix allowing projects to have - in their names.
 * Fix allowing groupID/artifactID naming convention.
 * Fix "No such namespace" when using om via the REPL.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ reports and pull requests are very welcome.
 ## Changelog
 
 ### Master
-* Version upgrades: clojurescript: 1.7.122 => 1.7.145, om: 0.9.0 => 1.0.0-alpha15, tools.nrepl => 0.2.12, figwheel => 0.4.1, figwheel-sidecar => 0.4.1, lein-figwheel => 0.4.1
+* Version upgrades: clojurescript: 1.7.122 => 1.7.145, om: 0.9.0 => 1.0.0-alpha15, tools.nrepl => 0.2.12, figwheel => 0.4.1, figwheel-sidecar => 0.4.1, lein-figwheel => 0.4.1,environ => 1.0.1, lein-environ => 1.0.1
 * Fix allowing projects to have - in their names.
 * Fix allowing groupID/artifactID naming convention.
 * Fix "No such namespace" when using om via the REPL.

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -20,7 +20,7 @@
                  [environ "1.0.1"]{{{project-clj-deps}}}]
 
   :plugins [[lein-cljsbuild "1.0.5"]
-            [lein-environ "1.0.0"]{{{project-plugins}}}]
+            [lein-environ "1.0.1"]{{{project-plugins}}}]
 
   :min-lein-version "2.5.0"
 

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -16,8 +16,8 @@
                  [bk/ring-gzip "0.1.1"]
                  [compojure "1.4.0"]
                  [enlive "1.1.6"]
-                 [org.omcljs/om "1.0.0-alpha14"]
-                 [environ "1.0.0"]{{{project-clj-deps}}}]
+                 [org.omcljs/om "1.0.0-alpha15"]
+                 [environ "1.0.1"]{{{project-clj-deps}}}]
 
   :plugins [[lein-cljsbuild "1.0.5"]
             [lein-environ "1.0.0"]{{{project-plugins}}}]
@@ -53,16 +53,16 @@
   :profiles {:dev {:source-paths ["env/dev/clj"]
                    :test-paths ["test/clj"]
 
-                   :dependencies [[figwheel "0.3.9"]
-                                  [figwheel-sidecar "0.3.9"]
+                   :dependencies [[figwheel "0.4.1"]
+                                  [figwheel-sidecar "0.4.1"]
                                   [com.cemerick/piggieback "0.2.1"]
-                                  [org.clojure/tools.nrepl "0.2.10"]
+                                  [org.clojure/tools.nrepl "0.2.12"]
                                   [weasel "0.7.0"]{{{project-dev-deps}}}]
 
                    :repl-options {:init-ns {{project-ns}}.server
                                   :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl{{{nrepl-middleware}}}]}
 
-                   :plugins [[lein-figwheel "0.3.9"]{{{project-dev-plugins}}}]
+                   :plugins [[lein-figwheel "0.4.1"]{{{project-dev-plugins}}}]
 
                    :figwheel {:http-server-root "public"
                               :server-port 3449

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -9,14 +9,14 @@
   :test-paths [{{{clj-test-src-path}}}]
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.122" :scope "provided"]
+                 [org.clojure/clojurescript "1.7.145" :scope "provided"]
                  [ring "1.4.0"]
                  [ring/ring-defaults "0.1.5"]
                  [slester/ring-browser-caching "0.1.1"]
                  [bk/ring-gzip "0.1.1"]
                  [compojure "1.4.0"]
                  [enlive "1.1.6"]
-                 [org.omcljs/om "0.9.0"]
+                 [org.omcljs/om "1.0.0-alpha14"]
                  [environ "1.0.0"]{{{project-clj-deps}}}]
 
   :plugins [[lein-cljsbuild "1.0.5"]


### PR DESCRIPTION
I've changed the version of clojurescript from 1.7.122 to 1.7.145 since 1.7.122 does not exists in clojar any more.
I've also changed the version of om to 1.0.0-alpha14.
Please merge my code.