### PR TITLE
clean task to remove resources/public/js

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -8,6 +8,8 @@
 
   :test-paths [{{{clj-test-src-path}}}]
 
+  :clean-targets ^{:protect false} [:target-path :compile-path "resources/public/js"]
+
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.145" :scope "provided"]
                  [ring "1.4.0"]


### PR DESCRIPTION
Cljsbuild clean has been deprecated.
Add lein stanza to clean path resources/public/js

This was found in an attempt at getting a sense of pushing out artifacts. After messing in the browser-repl, `lein uberjar` was pushing out the old js, and I was getting some interesting `goog not defined` errors.

I attempted `lein cljsbuild clean` but it's listed as deprecated now.
https://github.com/emezeske/lein-cljsbuild/issues/376

per http://clojureverse.org/t/how-to-upgrade-from-0-7-to-0-8/47/4 a force `rm -rf resources/public/js` works but I would expect a clean to do this for me.