### PR TITLE
Adding out-of-the-box figwheel reloading

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -38,7 +38,8 @@
               [{:id "app"
                 :source-paths ["src/cljs"]
 
-                ;; You can configure a function to run every time figwheel reloads.
+                :figwheel true
+                ;; Alternatively, you can configure a function to run every time figwheel reloads.
                 ;; :figwheel {:on-jsload "{{{project-ns}}}.core/on-figwheel-reload"}
 
                 :compiler {:main {{{project-ns}}}.core


### PR DESCRIPTION
Hey there! Finally got down to why chestnut wasn't reloading for me.

Turns out :figwheel true is necessary, but not in chestnut's generated config, which makes browser-repl not connect by default.

Sane default is to have it on, and add comments to change it if a reload function is warranted.