### PR TITLE
Adding missing dependency for css compilers

### DIFF
--- a/src/leiningen/new/chestnut/dev/user.clj
+++ b/src/leiningen/new/chestnut/dev/user.clj
@@ -1,7 +1,8 @@
 (ns user
   (:require [{{project-ns}}.server]
             [ring.middleware.reload :refer [wrap-reload]]
-            [figwheel-sidecar.repl-api :as figwheel]))
+            [figwheel-sidecar.repl-api :as figwheel]
+            [clojure.java.shell]))
 
 {{#less?}}
 (defn start-less []


### PR DESCRIPTION
Adding clojure.java.shell in :require for sass and less

Clojure 1.7 seems to need the explicit include. This fixes the --less flag issue I mentioned I was seeing.

Again, might be better to include only if sass/less flags are active, but this gets it working.