### PR TITLE
Only include dev source path when dev profile is active

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -18,7 +18,7 @@
 
   :min-lein-version "2.6.1"
 
-  :source-paths ["src/clj" "src/cljs" "dev"]
+  :source-paths ["src/clj" "src/cljs"]
 
   :test-paths ["test/clj"]
 
@@ -100,6 +100,8 @@
 
               :plugins [[lein-figwheel "0.5.1"]
                         [lein-doo "0.1.6"]]
+
+              :source-paths ["dev"]
 
               :cljsbuild {:builds
                           {:test


### PR DESCRIPTION
This avoids FileNotFoundException when running "lein jar".

"lein uberjar" was unaffected as it replaces source-paths.