### PR TITLE
Avoid using profile merging for `:cljsbuild` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ reports and pull requests are very welcome.
 
 ## Changelog
 
+### master
+
+* Avoid using Leiningen profile merging for `:cljsbuild` configs
+
 ### 0.12.0
 
 * Upgrades

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chestnut/lein-template "0.12.0"
+(defproject chestnut/lein-template "0.13.0-SNAPSHOT"
   :description "A Leiningen template for a ClojureScript setup with Figwheel, Om."
   :url "https://github.com/plexus/chestnut"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -49,7 +49,7 @@
           (less? opts) (conj "lein-less \"1.7.5\"")))
 
 (defn project-uberjar-hooks [opts]
-  (cond-> ["leiningen.cljsbuild"]
+  (cond-> []
           (less? opts) (conj "leiningen.less")
           (sass? opts) (conj "leiningen.sassc")))
 

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -35,8 +35,8 @@
   :repl-options {:init-ns user}
 
   :cljsbuild {:builds
-              {:app
-               {:source-paths ["src/cljs"]
+              [{:id "app"
+                :source-paths ["src/cljs"]
 
                 :figwheel true
                 ;; Alternatively, you can configure a function to run every time figwheel reloads.
@@ -46,7 +46,23 @@
                            :asset-path "js/compiled/out"
                            :output-to "resources/public/js/compiled/{{{sanitized}}}.js"
                            :output-dir "resources/public/js/compiled/out"
-                           :source-map-timestamp true}}}}
+                           :source-map-timestamp true}}
+
+               {:id "test"
+                :source-paths ["src/cljs" "test/cljs"]
+                :compiler {:output-to "resources/public/js/compiled/testable.js"
+                           :main {{{project-ns}}}.test-runner
+                           :optimizations :none}}
+
+               {:id "min"
+                :source-paths ["src/cljs"]
+                :jar true
+                :compiler {:main {{{project-ns}}}.core
+                           :output-to "resources/public/js/compiled/{{{sanitized}}}.js"
+                           :output-dir "target"
+                           :source-map-timestamp true
+                           :optimizations :advanced
+                           :pretty-print false}}]}
 
   ;; When running figwheel from nREPL, figwheel will read this configuration
   ;; stanza, but it will read it without passing through leiningen's profile
@@ -101,24 +117,11 @@
               :plugins [[lein-figwheel "0.5.3-2"]
                         [lein-doo "0.1.6"]]
 
-              :source-paths ["dev"]
-
-              :cljsbuild {:builds
-                          {:test
-                           {:source-paths ["src/cljs" "test/cljs"]
-                            :compiler
-                            {:output-to "resources/public/js/compiled/testable.js"
-                             :main {{{project-ns}}}.test-runner
-                             :optimizations :none}}}}}
+              :source-paths ["dev"]}
 
              :uberjar
              {:source-paths ^:replace ["src/clj"]
+              :prep-tasks ["compile" ["cljsbuild" "once" "min"]]
               :hooks [{{{project-uberjar-hooks}}}]
               :omit-source true
-              :aot :all
-              :cljsbuild {:builds
-                          {:app
-                           {:source-paths ^:replace ["src/cljs"]
-                            :compiler
-                            {:optimizations :advanced
-                             :pretty-print false}}}}}})
+              :aot :all}})


### PR DESCRIPTION
Relying on profile merging is not recommended because it doesn't play
well with Figwheel. While our old setup worked, it encourages people to
put cljsbuild stuff in profiles, causing them to run into all kinds of
random issues.

Closes #172