### PR TITLE
Flag for cljc

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Clojure/ClojureScript apps effectively. It comes with
   [ring.defaults documentation](https://github.com/ring-clojure/ring-defaults))
 * `--less` Use [less](https://github.com/montoux/lein-less) for
   compiling Less CSS files.
+* `--cljc` Generate source and test cljc files for cross compiling to both clojure and clojurescript (see [Clojure reader conditionals](https://clojure.org/guides/reader_conditionals))
 
 Use `--` to separate these options from Leiningen's options,
 e.g. `lein new chestnut foo --snapshot -- --http-kit`
@@ -163,6 +164,10 @@ reports and pull requests are very welcome.
          Clojure, Clojurescript, or existing libraries.
 
 ## Changelog
+
+## master
+
+* Add `--cljc` flag
 
 ### 0.13.0
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+* Add `--cljc` flag
+
 ## 0.12.0
 
 * Upgrades

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -21,7 +21,7 @@
   (wrap-indent identity n list))
 
 (def valid-options
-  ["http-kit" "site-middleware" "less" "sass" "reagent" "vanilla"])
+  ["http-kit" "site-middleware" "less" "sass" "reagent" "vanilla" "cljc"])
 
 (doseq [opt valid-options]
   (eval
@@ -86,6 +86,8 @@
    :sass?                (fn [block] (if (sass? opts) (str "\n" block) ""))
    :less?                (fn [block] (if (less? opts) (str "\n" block) ""))
 
+   :cljc?                (fn [block] (if (cljc? opts) (str block) ""))
+
    ;; stylesheets
    :less-sass-refer      (cond (sass? opts) " start-sass"
                                (less? opts) " start-less")
@@ -109,7 +111,8 @@
            "test/cljs/chestnut/test_runner.cljs"]
           (less? opts) (conj "src/less/style.less")
           (sass? opts) (conj "src/scss/style.scss")
-          (not (or (less? opts) (sass? opts))) (conj "resources/public/css/style.css")))
+          (not (or (less? opts) (sass? opts))) (conj "resources/public/css/style.css")
+          (cljc? opts) (conj "src/cljc/chestnut/common.cljc" "test/cljc/chestnut/common_test.cljc")))
 
 (defn format-files-args
   "Returns a list of pairs (vectors). The first element is the file name to

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -19,9 +19,9 @@
 
   :min-lein-version "2.6.1"
 
-  :source-paths ["src/clj" "src/cljs"]
+  :source-paths ["src/clj" "src/cljs"{{#cljc?}} "src/cljc"{{/cljc?}}]
 
-  :test-paths ["test/clj"]
+  :test-paths ["test/clj"{{#cljc?}} "test/cljc"{{/cljc?}}]
 
   :clean-targets ^{:protect false} [:target-path :compile-path "resources/public/js"]
 
@@ -37,7 +37,7 @@
 
   :cljsbuild {:builds
               [{:id "app"
-                :source-paths ["src/cljs"]
+                :source-paths ["src/cljs"{{#cljc?}} "src/cljc"{{/cljc?}}]
 
                 :figwheel true
                 ;; Alternatively, you can configure a function to run every time figwheel reloads.
@@ -50,13 +50,13 @@
                            :source-map-timestamp true}}
 
                {:id "test"
-                :source-paths ["src/cljs" "test/cljs"]
+                :source-paths ["src/cljs" "test/cljs"{{#cljc?}} "src/cljc" "test/cljc"{{/cljc?}}]
                 :compiler {:output-to "resources/public/js/compiled/testable.js"
                            :main {{{project-ns}}}.test-runner
                            :optimizations :none}}
 
                {:id "min"
-                :source-paths ["src/cljs"]
+                :source-paths ["src/cljs"{{#cljc?}} "src/cljc"{{/cljc?}}]
                 :jar true
                 :compiler {:main {{{project-ns}}}.core
                            :output-to "resources/public/js/compiled/{{{sanitized}}}.js"
@@ -122,7 +122,7 @@
               :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}
 
              :uberjar
-             {:source-paths ^:replace ["src/clj"]
+             {:source-paths ^:replace ["src/clj"{{#cljc?}} "src/cljc"{{/cljc?}}]
               :prep-tasks ["compile" ["cljsbuild" "once" "min"]]
               :hooks [{{{project-uberjar-hooks}}}]
               :omit-source true

--- a/src/leiningen/new/chestnut/src/cljc/chestnut/common.cljc
+++ b/src/leiningen/new/chestnut/src/cljc/chestnut/common.cljc
@@ -1,0 +1,7 @@
+(ns {{project-ns}}.common)
+
+(defn shared-fn
+  "A function that is shared between clj and cljs"
+  []
+  (println "cljc!"))
+

--- a/src/leiningen/new/chestnut/test/cljc/chestnut/common_test.cljc
+++ b/src/leiningen/new/chestnut/test/cljc/chestnut/common_test.cljc
@@ -1,0 +1,8 @@
+(ns {{project-ns}}.common-test
+  #? (:cljs (:require-macros [cljs.test :refer (is deftest testing)]))
+  (:require [{{project-ns}}.common :as sut]
+            #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test])))
+
+(deftest example-passing-test-cljc
+  (is (= 1 1)))

--- a/src/leiningen/new/chestnut/test/cljs/chestnut/test_runner.cljs
+++ b/src/leiningen/new/chestnut/test/cljs/chestnut/test_runner.cljs
@@ -1,8 +1,10 @@
 (ns {{project-ns}}.test-runner
   (:require
    [doo.runner :refer-macros [doo-tests]]
-   [{{project-ns}}.core-test]))
+   [{{project-ns}}.core-test]{{#cljc?}}
+   [{{project-ns}}.common-test]{{/cljc?}}))
 
 (enable-console-print!)
 
-(doo-tests '{{project-ns}}.core-test)
+(doo-tests '{{project-ns}}.core-test{{#cljc?}}
+           '{{project-ns}}.common-test{{/cljc?}})


### PR DESCRIPTION
Generates project, source, and test in cljc directories

I've seen some talk about doing this in #154 but I haven't seen any work done. So here's a quick something!

Alternatively, we could just have a cljc folder, source, and test included in the vanilla skeleton. Adding a flag seemed like a less heavy handed first step. Let me know what you think!