### PR TITLE
Fix lein-auto configuraton for SCSS compilation

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -104,7 +104,8 @@
   :sassc [{:src "src/scss/style.scss"
            :output-to "resources/public/css/style.css"}]
 
-  :auto {"sassc" {:file-pattern  #"\.(scss)$"}}
+  :auto {"sassc" {:file-pattern  #"\.(scss)$"
+                  :paths ["src/scss"]}}
 {{/sass?}}
 
   :profiles {:dev


### PR DESCRIPTION
According to lein-auto documentation:

> :paths - list of directories scanned for files. (defaults to concatenation of project :source-paths, :java-source-paths and :test-paths).'

None of those contain src/scss in our project.clj.