### PR TITLE
Use Figwheel to handle HTTP requests again

### DIFF
--- a/src/leiningen/new/chestnut/dev/user.clj
+++ b/src/leiningen/new/chestnut/dev/user.clj
@@ -10,7 +10,7 @@
 
 (defn dev-system []
   (merge
-   ({{project-ns}}.application/app-system)
+   (dissoc ({{project-ns}}.application/app-system) :web)
    (component/system-map
     :figwheel-system (fw-sys/figwheel-system (fw-config/fetch-config))
     :css-watcher (fw-sys/css-watcher {:watch-paths ["resources/public/css"]}){{extra-dev-components}})))
@@ -27,11 +27,16 @@
     (clojure.java.shell/sh "lein" "auto" "sassc" "once")))
 {{/sass?}}
 
-(set-refresh-dirs "src" "dev")
-(reloaded.repl/set-init! #(dev-system))
+(defn dev-ring-handler
+  "Passed to Figwheel so it can pass on requests"
+  [req]
+  ((get-in reloaded.repl/system [:handler :handler]) req))
 
 (defn run []
   (go){{less-sass-start}})
 
 (defn browser-repl []
   (fw-sys/cljs-repl (:figwheel-system system)))
+
+(set-refresh-dirs "src" "dev")
+(reloaded.repl/set-init! #(dev-system))

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -93,7 +93,8 @@
              ;;
              ;; :open-file-command "myfile-opener"
 
-             :server-logfile "log/figwheel.log"}
+             :server-logfile "log/figwheel.log"
+             :ring-handler user/dev-ring-handler}
 
   :doo {:build "test"}
 {{#less?}}

--- a/src/leiningen/new/chestnut/src/clj/chestnut/application.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/application.clj
@@ -8,21 +8,18 @@
             [system.components.endpoint :refer [new-endpoint]]
             [system.components.handler :refer [new-handler]]
             [system.components.middleware :refer [new-middleware]]{{{server-clj-requires}}}
-            [{{project-ns}}.routes :refer [routes]]))
+            [{{project-ns}}.routes :refer [new-routes]]))
 
 (defn app-system []
   (component/system-map
-   :routes (new-endpoint (fn [_] routes))
-   :middleware (new-middleware  {:middleware [[wrap-defaults :defaults]
-                                              wrap-with-logger
-                                              wrap-gzip]
-                                 :defaults {{ring-defaults}}})
-   :handler (component/using
-             (new-handler)
-             [:routes :middleware])
-   :http (component/using
-          (new-web-server (Integer. (or (env :port) 10555)))
-          [:handler])))
+   :routes (new-endpoint new-routes)
+   :middleware (new-middleware {:middleware [[wrap-defaults {{ring-defaults}}]
+                                             wrap-with-logger
+                                             wrap-gzip]})
+   :handler (-> (new-handler)
+                (component/using [:routes :middleware]))
+   :http (-> (new-web-server (Integer. (or (env :port) 10555)))
+             (component/using [:handler]))))
 
 (defn -main [& _]
   (component/start (app-system)))

--- a/src/leiningen/new/chestnut/src/clj/chestnut/routes.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/routes.clj
@@ -1,14 +1,15 @@
 (ns {{project-ns}}.routes
   (:require [clojure.java.io :as io]
-            [compojure.core :refer [ANY GET PUT POST DELETE defroutes]]
+            [compojure.core :refer [ANY GET PUT POST DELETE routes context]]
             [compojure.route :refer [resources]]
             [ring.util.response :refer [response]]))
 
-(defroutes routes
-  (GET "/" _
-    (-> "public/index.html"
-        io/resource
-        io/input-stream
-        response
-        (assoc :headers {"Content-Type" "text/html; charset=utf-8"})))
-  (resources "/"))
+(defn new-routes [endpoint]
+  (routes
+   (GET "/" _
+     (-> "public/index.html"
+         io/resource
+         io/input-stream
+         response
+         (assoc :headers {"Content-Type" "text/html; charset=utf-8"})))
+   (resources "/")))


### PR DESCRIPTION
By switching to Component we lost something we had previously: Figwheel as the
one and only HTTP server.

Instead Figwheel and jetty/http-kit would both get started. This is confusing
because now in dev mode API calls need to go to a different port. This is also
problematic because when used from the frontend it violates browsers Same Origin
Policy, meaning the frontend can no longer (without extra hassle, i.e. CORS
headers) make backend calls.

The new approach is to have a helper function in `(ns user)`,
`dev-ring-handler`, which takes a request, and delegates it to whatever the
current handler in the system map is. In `project.clj` Figwheel is told to use
this function as its ring handler.

The `:http` component is taken out of the system map in dev mode so we don't boot up an extra http server.

Another change is to use a regular function for the routes factory, rather than
the inline anonymous fn we had earlier. This is more how these Duct-style
endpoint components are intended to be used, and it opens the door to passing
dependencies into the routes.

@featheredtoast would love your thought on this!