### PR TITLE
Om next

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Clojure/ClojureScript apps effectively. It comes with
 * [Om](https://github.com/swannodette/om) ClojureScript interface to Facebook's
   React. Alternatively you can use Reagent (`+reagent`), use Rum (`+rum`), or use `+vanilla` to
   do without a React wrapper.
+* [Om-Next](https://github.com/swannodette/om) Next version of the ClojureScript interface to Facebook's React. Specify (`+om-next`).
 * [Ring](https://github.com/ring-clojure/ring) Clojure's de facto HTTP
   interface. Chestnut uses a Jetty or HttpKit server to serve the
   Clojurescript app. This way you already have an HTTP server running
@@ -170,6 +171,7 @@ reports and pull requests are very welcome.
   options. The `--` variants still work.
 - Bump versions: clojurescript 1.9.293, transit-clj 0.8.297, ring 1.5.0, ring-defaults 0.2.1, compojure 1.5.1, environ 1.1.0, reagent 0.6.0, figwheel 0.5.8, http-kit 2.2.0, om 1.0.0-alpha47, doo 0.1.7, lein-cljsbuild 1.1.5, lein-environ 1.1.0
 - Add Rum support. Use (`+rum`).
+- Add Om Next support. Use (`+om-next`).
 
 ### 0.14.0
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ in your generated project for instructions pertaining to your version.
 
 ```
 lein new chestnut <name>
+lein new chestnut <name> -- <options>  # see below
 ```
 
 After that open the README of your generated project for detailed

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -34,7 +34,7 @@
        ((indent n (next list)))))
 
 (def valid-options
-  ["http-kit" "site-middleware" "less" "sass" "reagent" "vanilla" "garden" "rum"])
+  ["http-kit" "site-middleware" "less" "sass" "reagent" "vanilla" "garden" "rum" "om-next"])
 
 (doseq [opt valid-options]
   (eval
@@ -44,7 +44,8 @@
 (defn om? [props]
   (and (not (reagent? props))
        (not (rum? props))
-       (not (vanilla? props))))
+       (not (vanilla? props))
+       (not (om-next? props))))
 
 (defn server-clj-requires [opts]
   (if (http-kit? opts)
@@ -62,6 +63,7 @@
     (http-kit? opts) (conj '[http-kit "2.2.0"])
     (reagent? opts)  (conj '[reagent "0.6.0"])
     (om? opts)       (conj '[org.omcljs/om "1.0.0-alpha47"])
+    (om-next? opts)  (conj '[org.omcljs/om "1.0.0-alpha47"])
     (rum? opts)      (conj '[rum "0.10.8"])
     (garden? opts)   (conj '[lambdaisland/garden-watcher "0.2.0"])))
 
@@ -167,6 +169,7 @@ render, the second is the file contents."
      ["src/cljs/{{sanitized}}/core.cljs"
       (render (cond
                 (om? opts) "src/cljs/chestnut/core_om.cljs"
+                (om-next? opts) "src/cljs/chestnut/core_om_next.cljs"
                 (reagent? opts) "src/cljs/chestnut/core_reagent.cljs"
                 (rum? opts) "src/cljs/chestnut/core_rum.cljs"
                 (vanilla? opts) "src/cljs/chestnut/core_vanilla.cljs")

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_om_next.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_om_next.cljs
@@ -1,0 +1,16 @@
+(ns {{project-ns}}.core
+  (:require [om.next :as om :refer-macros [defui]]
+            [om.dom :as dom]))
+
+(enable-console-print!)
+
+(defonce app-state (atom {:text "Hello Chestnut!"}))
+
+(defui RootComponent
+  Object
+  (render [this]
+    (dom/div nil (dom/h1 nil (:text @app-state)))))
+
+(def root (om/factory RootComponent))
+
+(js/ReactDOM.render (root) (js/document.getElementById "app"))


### PR DESCRIPTION
I wanted to generate an om.next skeleton instead of the old 'om' skeleton.
The library installed already supports both versions.

PS.  I thought a bit of clarification of how to specify the +rum, +reagent, +vanilla options would be helpful since it took me a while to figure out.