### PR TITLE
system version bump 0.4.0

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -13,7 +13,7 @@
                  [ring.middleware.logger "0.5.0"]
                  [compojure "1.5.1"]
                  [environ "1.1.0"]
-                 [com.stuartsierra/component "0.3.1"]
+                 [com.stuartsierra/component "0.4.0"]
                  [org.danielsz/system "0.3.1"]
                  [org.clojure/tools.namespace "0.2.11"]{{{project-clj-deps}}}]
 

--- a/src/leiningen/new/chestnut/src/clj/chestnut/application.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/application.clj
@@ -13,10 +13,9 @@
 (defn app-system []
   (component/system-map
    :routes (new-endpoint (fn [_] routes))
-   :middleware (new-middleware  {:middleware [[wrap-defaults :defaults]
+   :middleware (new-middleware  {:middleware [[wrap-defaults {{ring-defaults}}]
                                               wrap-with-logger
-                                              wrap-gzip]
-                                 :defaults {{ring-defaults}}})
+                                              wrap-gzip]})
    :handler (component/using
              (new-handler)
              [:routes :middleware])


### PR DESCRIPTION
0.3.2 of system came with a breaking change to middleware handlers.
https://github.com/danielsz/system/issues/48#issuecomment-270248608

PR with the version bump to save you from a case of the 'where did my wrap-defaults middleware go's ;)