### PR TITLE
Cljs system integration

### DIFF
--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -142,6 +142,7 @@
            "src/clj/chestnut/routes.clj"
            "src/cljc/chestnut/common.cljc"
            "dev/user.clj"
+           "dev/cljs/user.cljs"
            "LICENSE"
            "README.md"
            "code_of_conduct.md"

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -141,6 +141,8 @@
            "src/clj/chestnut/application.clj"
            "src/clj/chestnut/routes.clj"
            "src/cljc/chestnut/common.cljc"
+           "src/cljs/chestnut/system.cljs"
+           "src/cljs/chestnut/components/render.cljs"
            "dev/user.clj"
            "dev/cljs/user.cljs"
            "LICENSE"

--- a/src/leiningen/new/chestnut/dev/cljs/user.cljs
+++ b/src/leiningen/new/chestnut/dev/cljs/user.cljs
@@ -1,8 +1,8 @@
 (ns cljs.user
   (:require [{{project-ns}}.core]
-            [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
+            [{{project-ns}}.system :as system]))
 
-(def go reloaded/go)
-(def reset reloaded/reset)
-(def stop reloaded/stop)
-(def start reloaded/start)
+(def go system/go)
+(def reset system/reset)
+(def stop system/stop)
+(def start system/start)

--- a/src/leiningen/new/chestnut/dev/cljs/user.cljs
+++ b/src/leiningen/new/chestnut/dev/cljs/user.cljs
@@ -1,0 +1,8 @@
+(ns cljs.user
+  (:require [{{project-ns}}.core]
+            [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
+
+(def go reloaded/go)
+(def reset reloaded/reset)
+(def stop reloaded/stop)
+(def start reloaded/start)

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -15,8 +15,7 @@
                  [environ "1.1.0"]
                  [com.stuartsierra/component "0.3.2"]
                  [org.danielsz/system "0.4.0"]
-                 [org.clojure/tools.namespace "0.2.11"]
-                 [org.clojars.featheredtoast/reloaded-repl-cljs "0.1.0"]{{{project-clj-deps}}}]
+                 [org.clojure/tools.namespace "0.2.11"]{{{project-clj-deps}}}]
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-environ "1.1.0"]{{{project-plugins}}}]
@@ -44,7 +43,7 @@
               [{:id "app"
                 :source-paths ["src/cljs" "src/cljc" "dev"]
 
-                :figwheel {:on-jsload "org.clojars.featheredtoast.reloaded-repl-cljs/go"}
+                :figwheel {:on-jsload "{{project-ns}}.system/reset"}
 
                 :compiler {:main cljs.user
                            :asset-path "js/compiled/out"
@@ -61,7 +60,7 @@
                {:id "min"
                 :source-paths ["src/cljs" "src/cljc"]
                 :jar true
-                :compiler {:main {{{project-ns}}}.core
+                :compiler {:main {{{project-ns}}}.system
                            :output-to "resources/public/js/compiled/{{{sanitized}}}.js"
                            :output-dir "target"
                            :source-map-timestamp true

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -15,7 +15,8 @@
                  [environ "1.1.0"]
                  [com.stuartsierra/component "0.3.2"]
                  [org.danielsz/system "0.4.0"]
-                 [org.clojure/tools.namespace "0.2.11"]{{{project-clj-deps}}}]
+                 [org.clojure/tools.namespace "0.2.11"]
+                 [org.clojars.featheredtoast/reloaded-repl-cljs "0.1.0"]{{{project-clj-deps}}}]
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-environ "1.1.0"]{{{project-plugins}}}]
@@ -36,17 +37,16 @@
   ;; nREPL by default starts in the :main namespace, we want to start in `user`
   ;; because that's where our development helper functions like (run) and
   ;; (browser-repl) live.
-  :repl-options {:init-ns user}
+  :repl-options {:init-ns user
+                 :init (go)}
 
   :cljsbuild {:builds
               [{:id "app"
-                :source-paths ["src/cljs" "src/cljc"]
+                :source-paths ["src/cljs" "src/cljc" "dev"]
 
-                :figwheel true
-                ;; Alternatively, you can configure a function to run every time figwheel reloads.
-                ;; :figwheel {:on-jsload "{{{project-ns}}}.core/on-figwheel-reload"}
+                :figwheel {:on-jsload "org.clojars.featheredtoast.reloaded-repl-cljs/go"}
 
-                :compiler {:main {{{project-ns}}}.core
+                :compiler {:main cljs.user
                            :asset-path "js/compiled/out"
                            :output-to "resources/public/js/compiled/{{{sanitized}}}.js"
                            :output-dir "resources/public/js/compiled/out"

--- a/src/leiningen/new/chestnut/resources/public/index.html
+++ b/src/leiningen/new/chestnut/resources/public/index.html
@@ -8,5 +8,6 @@
   <body>
     <div id="app"></div>
     <script src="js/compiled/{{sanitized}}.js" type="text/javascript"></script>
+    <script type="text/javascript">{{project-ns}}.system.go();</script>
   </body>
 </html>

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/components/render.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/components/render.cljs
@@ -1,0 +1,13 @@
+(ns {{project-ns}}.components.render
+    (:require [com.stuartsierra.component :as component]
+              [{{project-ns}}.core :refer [render]]))
+
+(defrecord RenderComponent []
+  component/Lifecycle
+  (start [component]
+    (render)
+    component)
+  (stop [component]
+    component))
+(defn new-render-component []
+  (map->RenderComponent {}))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_om.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_om.cljs
@@ -1,6 +1,8 @@
 (ns {{project-ns}}.core
   (:require [om.core :as om :include-macros true]
-            [om.dom :as dom :include-macros true]))
+            [om.dom :as dom :include-macros true]
+            [com.stuartsierra.component :as component]
+            [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
 
 (enable-console-print!)
 
@@ -16,3 +18,19 @@
  root-component
  app-state
  {:target (js/document.getElementById "app")})
+
+(defrecord SampleComponent []
+  component/Lifecycle
+  (start [component]
+    (println "start component")
+    component)
+  (stop [component]
+    (println "stop component")
+    component))
+(defn new-sample-component []
+  (map->SampleComponent {}))
+
+(defn system []
+  (component/system-map
+   :sample-component (new-sample-component)))
+(reloaded/set-init-go! #(system))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_om.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_om.cljs
@@ -1,8 +1,6 @@
 (ns {{project-ns}}.core
   (:require [om.core :as om :include-macros true]
-            [om.dom :as dom :include-macros true]
-            [com.stuartsierra.component :as component]
-            [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
+            [om.dom :as dom :include-macros true]))
 
 (enable-console-print!)
 
@@ -14,23 +12,8 @@
     (render [_]
       (dom/div nil (dom/h1 nil (:text app))))))
 
-(om/root
- root-component
- app-state
- {:target (js/document.getElementById "app")})
-
-(defrecord SampleComponent []
-  component/Lifecycle
-  (start [component]
-    (println "start component")
-    component)
-  (stop [component]
-    (println "stop component")
-    component))
-(defn new-sample-component []
-  (map->SampleComponent {}))
-
-(defn system []
-  (component/system-map
-   :sample-component (new-sample-component)))
-(reloaded/set-init-go! #(system))
+(defn render []
+  (om/root
+   root-component
+   app-state
+   {:target (js/document.getElementById "app")}))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_om_next.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_om_next.cljs
@@ -1,6 +1,8 @@
 (ns {{project-ns}}.core
   (:require [om.next :as om :refer-macros [defui]]
-            [om.dom :as dom]))
+            [om.dom :as dom]
+            [com.stuartsierra.component :as component]
+            [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
 
 (enable-console-print!)
 
@@ -14,3 +16,19 @@
 (def root (om/factory RootComponent))
 
 (js/ReactDOM.render (root) (js/document.getElementById "app"))
+
+(defrecord SampleComponent []
+  component/Lifecycle
+  (start [component]
+    (println "start component")
+    component)
+  (stop [component]
+    (println "stop component")
+    component))
+(defn new-sample-component []
+  (map->SampleComponent {}))
+
+(defn system []
+  (component/system-map
+   :sample-component (new-sample-component)))
+(reloaded/set-init-go! #(system))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_om_next.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_om_next.cljs
@@ -1,8 +1,6 @@
 (ns {{project-ns}}.core
   (:require [om.next :as om :refer-macros [defui]]
-            [om.dom :as dom]
-            [com.stuartsierra.component :as component]
-            [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
+            [om.dom :as dom]))
 
 (enable-console-print!)
 
@@ -15,20 +13,5 @@
 
 (def root (om/factory RootComponent))
 
-(js/ReactDOM.render (root) (js/document.getElementById "app"))
-
-(defrecord SampleComponent []
-  component/Lifecycle
-  (start [component]
-    (println "start component")
-    component)
-  (stop [component]
-    (println "stop component")
-    component))
-(defn new-sample-component []
-  (map->SampleComponent {}))
-
-(defn system []
-  (component/system-map
-   :sample-component (new-sample-component)))
-(reloaded/set-init-go! #(system))
+(defn render []
+  (js/ReactDOM.render (root) (js/document.getElementById "app")))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_reagent.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_reagent.cljs
@@ -1,7 +1,5 @@
 (ns {{project-ns}}.core
-    (:require [reagent.core :as reagent :refer [atom]]
-              [com.stuartsierra.component :as component]
-              [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
+    (:require [reagent.core :as reagent :refer [atom]]))
 
 (enable-console-print!)
 
@@ -10,20 +8,5 @@
 (defn greeting []
   [:h1 (:text @app-state)])
 
-(reagent/render [greeting] (js/document.getElementById "app"))
-
-(defrecord SampleComponent []
-  component/Lifecycle
-  (start [component]
-    (println "start component")
-    component)
-  (stop [component]
-    (println "stop component")
-    component))
-(defn new-sample-component []
-  (map->SampleComponent {}))
-
-(defn system []
-  (component/system-map
-   :sample-component (new-sample-component)))
-(reloaded/set-init-go! #(system))
+(defn render []
+  (reagent/render [greeting] (js/document.getElementById "app")))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_reagent.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_reagent.cljs
@@ -1,5 +1,7 @@
 (ns {{project-ns}}.core
-  (:require [reagent.core :as reagent :refer [atom]]))
+    (:require [reagent.core :as reagent :refer [atom]]
+              [com.stuartsierra.component :as component]
+              [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
 
 (enable-console-print!)
 
@@ -9,3 +11,19 @@
   [:h1 (:text @app-state)])
 
 (reagent/render [greeting] (js/document.getElementById "app"))
+
+(defrecord SampleComponent []
+  component/Lifecycle
+  (start [component]
+    (println "start component")
+    component)
+  (stop [component]
+    (println "stop component")
+    component))
+(defn new-sample-component []
+  (map->SampleComponent {}))
+
+(defn system []
+  (component/system-map
+   :sample-component (new-sample-component)))
+(reloaded/set-init-go! #(system))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_rum.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_rum.cljs
@@ -1,5 +1,7 @@
 (ns {{project-ns}}.core
-  (:require [rum.core :as rum]))
+    (:require [rum.core :as rum]
+              [com.stuartsierra.component :as component]
+              [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
 
 (enable-console-print!)
 
@@ -9,3 +11,19 @@
    [:h1 (:text (rum/react app-state))])
 
 (rum/mount (greeting) (. js/document (getElementById "app")))
+
+(defrecord SampleComponent []
+  component/Lifecycle
+  (start [component]
+    (println "start component")
+    component)
+  (stop [component]
+    (println "stop component")
+    component))
+(defn new-sample-component []
+  (map->SampleComponent {}))
+
+(defn system []
+  (component/system-map
+   :sample-component (new-sample-component)))
+(reloaded/set-init-go! #(system))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_rum.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_rum.cljs
@@ -1,7 +1,5 @@
 (ns {{project-ns}}.core
-    (:require [rum.core :as rum]
-              [com.stuartsierra.component :as component]
-              [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
+    (:require [rum.core :as rum]))
 
 (enable-console-print!)
 
@@ -10,20 +8,5 @@
 (rum/defc greeting < rum/reactive []
    [:h1 (:text (rum/react app-state))])
 
-(rum/mount (greeting) (. js/document (getElementById "app")))
-
-(defrecord SampleComponent []
-  component/Lifecycle
-  (start [component]
-    (println "start component")
-    component)
-  (stop [component]
-    (println "stop component")
-    component))
-(defn new-sample-component []
-  (map->SampleComponent {}))
-
-(defn system []
-  (component/system-map
-   :sample-component (new-sample-component)))
-(reloaded/set-init-go! #(system))
+(defn render []
+  (rum/mount (greeting) (. js/document (getElementById "app"))))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_vanilla.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_vanilla.cljs
@@ -1,6 +1,25 @@
-(ns {{project-ns}}.core)
+(ns {{project-ns}}.core
+    (:require [rum.core :as rum]
+              [com.stuartsierra.component :as component]
+              [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
 
 (enable-console-print!)
 
 (set! (.-innerHTML (js/document.getElementById "app"))
       "<h1>Hello Chestnut!</h1>")
+
+(defrecord SampleComponent []
+  component/Lifecycle
+  (start [component]
+    (println "start component")
+    component)
+  (stop [component]
+    (println "stop component")
+    component))
+(defn new-sample-component []
+  (map->SampleComponent {}))
+
+(defn system []
+  (component/system-map
+   :sample-component (new-sample-component)))
+(reloaded/set-init-go! #(system))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_vanilla.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_vanilla.cljs
@@ -1,25 +1,7 @@
-(ns {{project-ns}}.core
-    (:require [rum.core :as rum]
-              [com.stuartsierra.component :as component]
-              [org.clojars.featheredtoast.reloaded-repl-cljs :as reloaded]))
+(ns {{project-ns}}.core)
 
 (enable-console-print!)
 
-(set! (.-innerHTML (js/document.getElementById "app"))
-      "<h1>Hello Chestnut!</h1>")
-
-(defrecord SampleComponent []
-  component/Lifecycle
-  (start [component]
-    (println "start component")
-    component)
-  (stop [component]
-    (println "stop component")
-    component))
-(defn new-sample-component []
-  (map->SampleComponent {}))
-
-(defn system []
-  (component/system-map
-   :sample-component (new-sample-component)))
-(reloaded/set-init-go! #(system))
+(defn render []
+  (set! (.-innerHTML (js/document.getElementById "app"))
+        "<h1>Hello Chestnut!</h1>"))

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/system.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/system.cljs
@@ -1,0 +1,26 @@
+(ns {{project-ns}}.system
+    (:require [com.stuartsierra.component :as component]
+              [{{project-ns}}.components.render :refer [new-render-component]]))
+
+(declare system)
+
+(defn new-system []
+  (component/system-map
+   :app-root (new-render-component)))
+
+(defn init []
+  (set! system (new-system)))
+
+(defn start []
+  (set! system (component/start system)))
+
+(defn stop []
+  (set! system (component/stop system)))
+
+(defn ^:export go []
+  (init)
+  (start))
+
+(defn reset []
+  (stop)
+  (go))


### PR DESCRIPTION
Here's a working proof of concept with system integration for cljs for you to review. I've been favoring this setup in a personal project and the patch here is a simple port back to chestnut.

Go ahead and see how you like this. In general, I'd love to hear what you're envisioning for component integration on the cljs side, and I hope this patch is a good starting point for discussion.

- This is currently dependent on my cljs fork of reloaded.repl.
- I've modified the repl :init to run (go) for dev ease. This can go if it's unwanted.
- The sample component and system is copy-pasted to each of the cljs templates. Currently this system prints out messages on start/stop. I'm *sure* there's a better way to do this bit.
- I've added a dev/cljs/user.cljs for dev builds that refers to the reloaded repl cljs' go, start, stop, and reset functions for easier control in an attempt to mirror the same kind of control as clojure's user namespace.
- A figwheel hook resets the system on code reload.
- [x] It's currently including the recently submitted system patch fix so it's in a working state. I'll rebase once that patch is merged.