### PR TITLE
re-frame support (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### [Unreleased]
 
 - Add Component support, both backend and frontend
+- Add a `+re-frame` flag, for [re-frame](https://github.com/Day8/re-frame) projects
+- Bump versions: clojurescript 1.9.542, transit-clj 0.8.300, ring 1.6.1, ring-defaults 0.3.0, compojure 1.6.0, figwheel 0.5.10, figwheel-sidecar 0.5.10, org.clojure/tools.nrepl 0.2.13, om 1.0.0-alpha48
 
 ### 0.15.0-SNAPSHOT
 

--- a/README.md
+++ b/README.md
@@ -107,16 +107,25 @@ Clojure/ClojureScript apps effectively. It comes with
 
 ## Options
 
-* `+reagent` Use Reagent instead of Om
-* `+rum` Use Rum instead of Om
-* `+vanilla` Don't include Om, use this if you intend to use some other view library
-* `+http-kit` Use [HTTP Kit](http://http-kit.org/server.html) instead
-  of Jetty
-* `+site-middleware` Use the `ring.middleware.defaults.site-defaults` middleware
-  (session, CSRF), instead of `ring.middleware.defaults.api-defaults` (see
+General options:
+
+- `+http-kit` Use [HTTP Kit](http://http-kit.org/server.html) instead of Jetty
+- `+site-middleware` Use the `ring.middleware.defaults.site-defaults` middleware (session, CSRF), instead of `ring.middleware.defaults.api-defaults` (see
   [ring.defaults documentation](https://github.com/ring-clojure/ring-defaults))
-* `+less` Use [less](https://github.com/montoux/lein-less) for
-  compiling Less CSS files.
+
+Choice of UI library:
+
+- `+vanilla` Don't include Om, use this if you intend to use some other view library
+- `+om-next` Use om.next, instead of legacy Om
+- `+reagent` Use Reagent instead of Om
+- `+re-frame` Use Reagent and re-frame
+- `+rum` Use Rum instead of Om
+
+Choice of CSS style:
+
+- `+less` Use [less](https://github.com/montoux/lein-less) for compiling Less CSS files.
+- `+sass` Use SASS for generating CSS
+- `+garden` Use Garden for generating CSS
 
 ## Local copy
 

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
   :eval-in-leiningen true
 
   :dependencies [[com.github.plexus/clj-jgit "v0.8.9-preview"]
-                 [org.slf4j/slf4j-nop "1.7.22"]]
+                 [org.slf4j/slf4j-nop "1.7.22"]
+                 [re-frame/lein-template "0.2.7-1"]]
 
   :profiles {:test {:dependencies [[org.clojure/core.async "0.2.395"]
                                    [com.github.jnr/jnr-process "1.0-SNAPSHOT"]

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -62,8 +62,8 @@
   (cond-> []
     (http-kit? opts) (conj '[http-kit "2.2.0"])
     (reagent? opts)  (conj '[reagent "0.6.0"])
-    (om? opts)       (conj '[org.omcljs/om "1.0.0-alpha47"])
-    (om-next? opts)  (conj '[org.omcljs/om "1.0.0-alpha47"])
+    (om? opts)       (conj '[org.omcljs/om "1.0.0-alpha48"])
+    (om-next? opts)  (conj '[org.omcljs/om "1.0.0-alpha48"])
     (rum? opts)      (conj '[rum "0.10.8"])
     (re-frame? opts) (conj '[re-frame "0.9.2"])
     (garden? opts)   (conj '[lambdaisland/garden-watcher "0.3.1"])))

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [leiningen.core.main :as main]
-            [leiningen.new.templates :refer [->files name-to-path project-name renderer sanitize-ns]])
+            [leiningen.new.templates :refer [->files name-to-path project-name render-text renderer sanitize-ns slurp-resource]])
   (:import java.io.Writer))
 
 ;; When using `pr`, output quoted forms as 'foo, and not as (quote foo)
@@ -34,7 +34,7 @@
        ((indent n (next list)))))
 
 (def valid-options
-  ["http-kit" "site-middleware" "less" "sass" "reagent" "vanilla" "garden" "rum" "om-next"])
+  ["http-kit" "site-middleware" "less" "sass" "reagent" "vanilla" "garden" "rum" "om-next" "re-frame"])
 
 (doseq [opt valid-options]
   (eval
@@ -45,7 +45,8 @@
   (and (not (reagent? props))
        (not (rum? props))
        (not (vanilla? props))
-       (not (om-next? props))))
+       (not (om-next? props))
+       (not (re-frame? props))))
 
 (defn server-clj-requires [opts]
   (if (http-kit? opts)
@@ -57,7 +58,6 @@
     (or (sass? opts) (less? opts)) (conj '[clojure.java.io :as io])
     (garden? opts)                 (conj '[garden-watcher.core :refer [new-garden-watcher]])))
 
-
 (defn project-clj-deps [opts]
   (cond-> []
     (http-kit? opts) (conj '[http-kit "2.2.0"])
@@ -65,6 +65,7 @@
     (om? opts)       (conj '[org.omcljs/om "1.0.0-alpha47"])
     (om-next? opts)  (conj '[org.omcljs/om "1.0.0-alpha47"])
     (rum? opts)      (conj '[rum "0.10.8"])
+    (re-frame? opts) (conj '[re-frame "0.9.2"])
     (garden? opts)   (conj '[lambdaisland/garden-watcher "0.3.1"])))
 
 (defn project-plugins [opts]
@@ -175,8 +176,21 @@
                 (om-next? opts) "src/cljs/chestnut/core_om_next.cljs"
                 (reagent? opts) "src/cljs/chestnut/core_reagent.cljs"
                 (rum? opts) "src/cljs/chestnut/core_rum.cljs"
-                (vanilla? opts) "src/cljs/chestnut/core_vanilla.cljs")
+                (vanilla? opts) "src/cljs/chestnut/core_vanilla.cljs"
+                (re-frame? opts) "src/cljs/chestnut/core_re_frame.cljs")
               data)])))
+
+(defn re-frame-render
+  [resource-path data]
+  (-> (str "leiningen/new/re_frame/" resource-path)
+      io/resource
+      slurp-resource
+      (render-text data)))
+
+(defn re-frame-files [data]
+  (for [f ["config" "db" "subs" "events" "views"]]
+    [(str "src/cljs/{{sanitized}}/" f ".cljs")
+     (re-frame-render (str "src/cljs/" f ".cljs") data)]))
 
 (defn chestnut [name & opts]
   (let [dash-opts (map (partial str "--") valid-options)
@@ -192,7 +206,10 @@
     (main/info "WARNING: being available on your system."))
 
   (let [data (template-data name opts)]
-    (apply ->files data (format-files-args data opts)))
+    (apply ->files data (format-files-args data opts))
+
+    (when (re-frame? opts)
+      (apply ->files data (re-frame-files (assoc data :ns-name (:project-ns data))))))
 
   (git-init name)
   (let [repo (load-repo name)]

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -5,13 +5,13 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.495" :scope "provided"]
-                 [com.cognitect/transit-clj "0.8.297"]
-                 [ring "1.5.1"]
-                 [ring/ring-defaults "0.2.3"]
+                 [org.clojure/clojurescript "1.9.542" :scope "provided"]
+                 [com.cognitect/transit-clj "0.8.300"]
+                 [ring "1.6.1"]
+                 [ring/ring-defaults "0.3.0"]
                  [bk/ring-gzip "0.2.1"]
                  [lambdaisland/ring.middleware.logger "0.5.1"]
-                 [compojure "1.5.1"]
+                 [compojure "1.6.0"]
                  [environ "1.1.0"]
                  [com.stuartsierra/component "0.3.2"]
                  [org.danielsz/system "0.4.0"]
@@ -95,27 +95,27 @@
              :server-logfile "log/figwheel.log"}
 
   :doo {:build "test"}
-{{#less?}}
+  {{#less?}}
   :less {:source-paths ["src/less"]
          :target-path "resources/public/css"}
-{{/less?}}
-{{#sass?}}
+  {{/less?}}
+  {{#sass?}}
   :sassc [{:src "src/scss/style.scss"
            :output-to "resources/public/css/style.css"}]
 
   :auto {"sassc" {:file-pattern  #"\.(scss)$"
                   :paths ["src/scss"]}}
-{{/sass?}}
+  {{/sass?}}
 
   :profiles {:dev
-             {:dependencies [[figwheel "0.5.9"]
-                             [figwheel-sidecar "0.5.9"]
+             {:dependencies [[figwheel "0.5.10"]
+                             [figwheel-sidecar "0.5.10"]
                              [com.cemerick/piggieback "0.2.1"]
-                             [org.clojure/tools.nrepl "0.2.12"]
+                             [org.clojure/tools.nrepl "0.2.13"]
                              [lein-doo "0.1.7"]
                              [reloaded.repl "0.2.3"]]
 
-              :plugins [[lein-figwheel "0.5.9"]
+              :plugins [[lein-figwheel "0.5.10"]
                         [lein-doo "0.1.7"]]
 
               :source-paths ["dev"]

--- a/src/leiningen/new/chestnut/src/cljs/chestnut/core_re_frame.cljs
+++ b/src/leiningen/new/chestnut/src/cljs/chestnut/core_re_frame.cljs
@@ -1,0 +1,24 @@
+(ns {{project-ns}}.core
+  (:require [reagent.core :as reagent]
+            [re-frame.core :as re-frame]
+            [{{project-ns}}.events]
+            [{{project-ns}}.subs]
+            [{{project-ns}}.views :as views]
+            [{{project-ns}}.config :as config]))
+
+(enable-console-print!)
+
+(defn dev-setup []
+  (when config/debug?
+    (enable-console-print!)
+    (println "dev mode")))
+
+(defn mount-root []
+  (re-frame/clear-subscription-cache!)
+  (reagent/render [views/main-panel]
+                  (.getElementById js/document "app")))
+
+(defn render []
+  (re-frame/dispatch-sync [:initialize-db])
+  (dev-setup)
+  (mount-root))


### PR DESCRIPTION
Adds a re-frame flag which adds re-frame as a dependency, and creates the
typical re-frame structure of db/subs/views/events.

This uses the templates directly from re-frame-template. At the moment only the
basic vanilla re-frame template is supported, but it would be easy to add
support for +re-frisk or +re-com.