### PR TITLE
Pre 0.15.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add Component support, both backend and frontend
 - Add a `+re-frame` flag, for [re-frame](https://github.com/Day8/re-frame) projects
+- remove `:repl-options {:init (go)}` from `project.clj`. You'll have to call `(go)` yourself after starting a REPL
+- clean up the SASS/LESS support. It's still a hack, but a slightly cleaner hack
+- Make `code_of_conduct.md` optional (`+coc` or `+code-of-conduct` flag to add it back)
+- Make `browser-repl` and `run` deprecated, in favor of `cljs-repl` and `go`
 - Bump versions: clojurescript 1.9.542, transit-clj 0.8.300, ring 1.6.1, ring-defaults 0.3.0, compojure 1.6.0, figwheel 0.5.10, figwheel-sidecar 0.5.10, org.clojure/tools.nrepl 0.2.13, om 1.0.0-alpha48
 
 ### 0.15.0-SNAPSHOT

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Choice of CSS style:
 - `+sass` Use SASS for generating CSS
 - `+garden` Use Garden for generating CSS
 
+Other
+
+- `+code-of-conduct` / `+coc` Add the [contributor covenant](http://contributor-covenant.org/) Code of Conduct
+
 ## Local copy
 
 If you want to customize Chestnut, or try unreleased features, you can

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -141,6 +141,7 @@
            "resources/log4j.properties"
            "src/clj/chestnut/application.clj"
            "src/clj/chestnut/routes.clj"
+           "src/clj/chestnut/config.clj"
            "src/cljc/chestnut/common.cljc"
            "src/cljs/chestnut/system.cljs"
            "src/cljs/chestnut/components/ui.cljs"

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -34,7 +34,7 @@
        ((indent n (next list)))))
 
 (def valid-options
-  ["http-kit" "site-middleware" "less" "sass" "reagent" "vanilla" "garden" "rum" "om-next" "re-frame"])
+  ["http-kit" "site-middleware" "less" "sass" "reagent" "vanilla" "garden" "rum" "om-next" "re-frame" "code-of-conduct" "coc"])
 
 (doseq [opt valid-options]
   (eval
@@ -148,7 +148,6 @@
            "dev/cljs/user.cljs"
            "LICENSE"
            "README.md"
-           "code_of_conduct.md"
            ".gitignore"
            "system.properties"
            ".dir-locals.el"
@@ -156,6 +155,7 @@
            "test/cljs/chestnut/core_test.cljs"
            "test/cljs/chestnut/test_runner.cljs"
            "test/cljc/chestnut/common_test.cljc"]
+    (or (coc? opts) (code-of-conduct? opts)) (conj "code_of_conduct.md")
     (less? opts) (conj "src/less/style.less")
     (sass? opts) (conj "src/scss/style.scss")
     (garden? opts) (conj "src/clj/chestnut/styles.clj")

--- a/src/leiningen/new/chestnut/dev/user.clj
+++ b/src/leiningen/new/chestnut/dev/user.clj
@@ -4,34 +4,30 @@
             [figwheel-sidecar.config :as fw-config]
             [figwheel-sidecar.system :as fw-sys]
             [clojure.tools.namespace.repl :refer [set-refresh-dirs]]
-            [reloaded.repl :refer [system init start stop go reset reset-all]]
+            [reloaded.repl :refer [system init]]
             [ring.middleware.reload :refer [wrap-reload]]
-            [figwheel-sidecar.repl-api :as figwheel]{{user-clj-requires}}))
+            [figwheel-sidecar.repl-api :as figwheel]{{user-clj-requires}}
+            [{{project-ns}}.config :refer [config]]))
 
 (defn dev-system []
-  (merge
-   ({{project-ns}}.application/app-system)
-   (component/system-map
+  (assoc ({{project-ns}}.application/app-system (config))
     :figwheel-system (fw-sys/figwheel-system (fw-config/fetch-config))
-    :css-watcher (fw-sys/css-watcher {:watch-paths ["resources/public/css"]}){{extra-dev-components}})))
-{{#less?}}
-(defn start-less []
-  (future
-    (println "Starting less.")
-    (clojure.java.shell/sh "lein" "less" "auto")))
-{{/less?}}
-{{#sass?}}
-(defn start-sass []
-  (future
-    (println "Starting sass.")
-    (clojure.java.shell/sh "lein" "auto" "sassc" "once")))
-{{/sass?}}
+    :css-watcher (fw-sys/css-watcher {:watch-paths ["resources/public/css"]}){{{extra-dev-components}}}))
 
 (set-refresh-dirs "src" "dev")
 (reloaded.repl/set-init! #(dev-system))
 
-(defn run []
-  (go){{less-sass-start}})
-
-(defn browser-repl []
+(defn cljs-repl []
   (fw-sys/cljs-repl (:figwheel-system system)))
+
+;; Set up aliases so they don't accidentally
+;; get scrubbed from the namespace declaration
+(def start reloaded.repl/start)
+(def stop reloaded.repl/stop)
+(def go reloaded.repl/go)
+(def reset reloaded.repl/reset)
+(def reset-all reloaded.repl/reset-all)
+
+;; deprecated, to be removed in Chestnut 1.0
+(def run go)
+(def browser-repl cljs-repl)

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -34,10 +34,9 @@
   :main {{{project-ns}}}.application
 
   ;; nREPL by default starts in the :main namespace, we want to start in `user`
-  ;; because that's where our development helper functions like (run) and
+  ;; because that's where our development helper functions like (go) and
   ;; (browser-repl) live.
-  :repl-options {:init-ns user
-                 :init (go)}
+  :repl-options {:init-ns user}
 
   :cljsbuild {:builds
               [{:id "app"

--- a/src/leiningen/new/chestnut/src/clj/chestnut/components/shell_component.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/components/shell_component.clj
@@ -1,0 +1,14 @@
+(ns {{project-ns}}.components.shell-component
+  (:require [com.stuartsierra.component :as component]
+            [clojure.string :as str]))
+
+(defrecord ShellComponent [command]
+  component/Lifecycle
+  (start [this]
+    (if-not (:running this)
+      (println "Shell command:" (str/join " " command))
+      (future (apply clojure.java.shell/sh command)))
+    (assoc this :running true)))
+
+(defn shell-component [& cmd]
+  (->ShellComponent cmd))

--- a/src/leiningen/new/chestnut/src/clj/chestnut/config.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/config.clj
@@ -1,0 +1,11 @@
+(ns {{project-ns}}.config
+  (:require [environ.core :refer [env]]
+            [ring.middleware.defaults :refer [wrap-defaults {{ring-defaults}}]]
+            [ring.middleware.gzip :refer [wrap-gzip]]
+            [ring.middleware.logger :refer [wrap-with-logger]]))
+
+(defn config []
+  {:http-port  (Integer. (or (env :port) 10555))
+   :middleware [[wrap-defaults {{ring-defaults}}]
+                wrap-with-logger
+                wrap-gzip]})

--- a/src/leiningen/new/chestnut/src/clj/chestnut/routes.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/routes.clj
@@ -1,14 +1,15 @@
 (ns {{project-ns}}.routes
   (:require [clojure.java.io :as io]
-            [compojure.core :refer [ANY GET PUT POST DELETE defroutes]]
+            [compojure.core :refer [ANY GET PUT POST DELETE routes]]
             [compojure.route :refer [resources]]
             [ring.util.response :refer [response]]))
 
-(defroutes routes
-  (GET "/" _
-    (-> "public/index.html"
-        io/resource
-        io/input-stream
-        response
-        (assoc :headers {"Content-Type" "text/html; charset=utf-8"})))
-  (resources "/"))
+(defn home-routes [endpoint]
+  (routes
+   (GET "/" _
+     (-> "public/index.html"
+         io/resource
+         io/input-stream
+         response
+         (assoc :headers {"Content-Type" "text/html; charset=utf-8"})))
+   (resources "/")))


### PR DESCRIPTION
### Get rid of `:repl-options {:init (go)}`
    
Just starting a REPL should not start the system, otherwise it becomes impossible to run multiple repls in parallel. Chestnut has always had an extra step to kick things into gear (before: `(run)`, now: `(go)`), and I think that's the better way to do things.

### Clean up +sass and +less

These two features were contributed to Chestnut, but always felt like a hack, both on the Chestnut implementation side (they didn't follow the conventions that other feature flags use), and in the generated code (calling lein through clojure.java.shell/sh, really?) 

It's still a hack, but one that at least kind of follows the established conventions. I've introduced a ShellComponent so that they can take part in the component lifecycle instead of doing their own thing. This still uses clojure.java.shell/sh, meaning you can't stop/restart them, once they're running they will keep running, and you don't get any feedback about what those processes are doing. Whatever ends up on stdout or stderr goes into a black hole. 

### Explicit reloaded.repl aliases in `user`

With these changes in, there is no longer a distinction between `go` and `run`, and one can simply be an alias of the other. 

I've also set up explicit aliases in `user` for the reloaded.repl stuff (stop, start, reset, etc), so that nrepl-refactor users don't end up having those scrubbed from the namespace declaration. 

`browser-repl` and `run` are simply aliases for `cljs-repl` and `go`, and are considered deprecated. We'll keep them for now, but drop them in Chestnut 1.0.

### Add a config namespace, pass config in explicitly
    
It is a common pattern to pass some kind of config map into the system constructor function, and we should do that by default. This also changes routes from defroutes to a constructor function, so you can pass dependencies to the routes through the endpoint component.

### Make code of conduct optional (+coc or +code-of-conduct)

It's been good that we pushed projects to adopt a CoC, but people should do this in an informed and deliberate way.