### PR TITLE
Make cljc code reloadable.

### DIFF
--- a/src/leiningen/new/chestnut/.gitignore
+++ b/src/leiningen/new/chestnut/.gitignore
@@ -13,3 +13,4 @@
 figwheel_server.log
 pom.xml
 pom.xml.asc
+/dev-target

--- a/src/leiningen/new/chestnut/dev/user.clj
+++ b/src/leiningen/new/chestnut/dev/user.clj
@@ -3,18 +3,22 @@
             [com.stuartsierra.component :as component]
             [figwheel-sidecar.config :as fw-config]
             [figwheel-sidecar.system :as fw-sys]
-            [clojure.tools.namespace.repl :refer [set-refresh-dirs]]
             [reloaded.repl :refer [system init]]
             [ring.middleware.reload :refer [wrap-reload]]
+            [ring.middleware.file :refer [wrap-file]]
+            [system.components.middleware :refer [new-middleware]]
             [figwheel-sidecar.repl-api :as figwheel]{{user-clj-requires}}
             [{{project-ns}}.config :refer [config]]))
 
 (defn dev-system []
-  (assoc ({{project-ns}}.application/app-system (config))
-    :figwheel-system (fw-sys/figwheel-system (fw-config/fetch-config))
-    :css-watcher (fw-sys/css-watcher {:watch-paths ["resources/public/css"]}){{{extra-dev-components}}}))
+  (let [config (config)]
+    (assoc ({{project-ns}}.application/app-system config)
+           :middleware (new-middleware
+                        {:middleware
+                         (conj (:middleware config) [wrap-file "dev-target/public"])})
+           :figwheel-system (fw-sys/figwheel-system (fw-config/fetch-config))
+           :css-watcher (fw-sys/css-watcher {:watch-paths ["resources/public/css"]}){{{extra-dev-components}}})))
 
-(set-refresh-dirs "src" "dev")
 (reloaded.repl/set-init! #(dev-system))
 
 (defn cljs-repl []

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -26,7 +26,7 @@
 
   :test-paths ["test/clj" "test/cljc"]
 
-  :clean-targets ^{:protect false} [:target-path :compile-path "resources/public/js"]
+  :clean-targets ^{:protect false} [:target-path :compile-path "resources/public/js" "dev-target"]
 
   :uberjar-name "{{{name}}}.jar"
 
@@ -46,13 +46,13 @@
 
                 :compiler {:main cljs.user
                            :asset-path "js/compiled/out"
-                           :output-to "resources/public/js/compiled/{{{sanitized}}}.js"
-                           :output-dir "resources/public/js/compiled/out"
+                           :output-to "dev-target/public/js/compiled/{{{sanitized}}}.js"
+                           :output-dir "dev-target/public/js/compiled/out"
                            :source-map-timestamp true}}
 
                {:id "test"
                 :source-paths ["src/cljs" "test/cljs" "src/cljc" "test/cljc"]
-                :compiler {:output-to "resources/public/js/compiled/testable.js"
+                :compiler {:output-to "dev-target/public/js/compiled/testable.js"
                            :main {{{project-ns}}}.test-runner
                            :optimizations :none}}
 


### PR DESCRIPTION
Add dev-target js compiling folder to disallow cljs name conflicts during a
reload. dev-target feels like the best name to mirror 'target', but I am open to discussion here.

Re-enable wrap-reload in the dev environment, allowing routes to reload automatically on change, without a system restart.

This is in an effort to address some of the [issues brought up on the mailing list.](http://clojureverse.org/t/pain-points-in-current-chestnut/402)