### PR TITLE
add an info component to print where to connect to the application

### DIFF
--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -148,6 +148,7 @@
            "src/clj/chestnut/application.clj"
            "src/clj/chestnut/routes.clj"
            "src/clj/chestnut/config.clj"
+           "src/clj/chestnut/components/server_info.clj"
            "src/cljc/chestnut/common.cljc"
            "src/cljs/chestnut/system.cljs"
            "src/cljs/chestnut/components/ui.cljs"

--- a/src/leiningen/new/chestnut/src/clj/chestnut/application.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/application.clj
@@ -1,6 +1,7 @@
 (ns {{project-ns}}.application
   (:gen-class)
   (:require [com.stuartsierra.component :as component]
+            [{{project-ns}}.components.server-info :refer [server-info]]
             [system.components.endpoint :refer [new-endpoint]]
             [system.components.handler :refer [new-handler]]
             [system.components.middleware :refer [new-middleware]]{{{server-clj-requires}}}
@@ -14,11 +15,11 @@
    :handler    (-> (new-handler)
                    (component/using [:routes :middleware]))
    :http       (-> (new-web-server (:http-port config))
-                   (component/using [:handler]))))
+                   (component/using [:handler]))
+   :server-info (server-info (:http-port config))))
 
 (defn -main [& _]
   (let [config (config)]
     (-> config
         app-system
-        component/start)
-    (println "Started {{project-ns}} on" (str "http://localhost:" (:http-port config)))))
+        component/start)))

--- a/src/leiningen/new/chestnut/src/clj/chestnut/components/server_info.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/components/server_info.clj
@@ -1,0 +1,12 @@
+(ns {{project-ns}}.components.server-info
+  (:require [com.stuartsierra.component :as component]))
+
+(defrecord ServerInfoPrinter [http-port]
+  component/Lifecycle
+  (start [component]
+    (println "Started {{project-ns}} on" (str "http://localhost:" http-port))
+    component)
+  (stop [component]
+    component))
+(defn server-info [http-port]
+  (->ServerInfoPrinter http-port))


### PR DESCRIPTION
Have a component that prints out where the server starts, so it gets printed when the system starts, rather than when main is called. This adds an info line to how to connect to your application, even when main isn't called (eg, starting from the repl, in dev mode).

Not against a redirect, but I feel like there should be some sort of print line in any environment.

(Partially) Addresses [the first point brought up on the mailing list](http://clojureverse.org/t/pain-points-in-current-chestnut/402).

This might be overkill - we could alternatively just print in an overridden `(go)` function, or something of that nature, but this ensures that we print the message every time the system is started.