### PR TITLE
Bleeding edge option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### master (unreleased)
+
+- Add `+edge` and `+bleeding-edge` options for automatically using the latest version of dependencies.
+
 ### [0.15.2] - 2017-07-30
 
 - Update more docs to refer to `(go)` and `(cljs-repl)` instead of `(run)` and `(browser-repl)`

--- a/README.md
+++ b/README.md
@@ -120,25 +120,27 @@ Clojure/ClojureScript apps effectively. It comes with
 
 General options:
 
-- `+no-poll` Opt out of usage statistics poll
-- `+http-kit` Use [HTTP Kit](http://http-kit.org/server.html) instead of Jetty
+- `+no-poll` Opt out of usage statistics poll.
+- `+http-kit` Use [HTTP Kit](http://http-kit.org/server.html) instead of Jetty.
 - `+site-middleware` Use the `ring.middleware.defaults.site-defaults` middleware (session, CSRF), instead of `ring.middleware.defaults.api-defaults` (see
-  [ring.defaults documentation](https://github.com/ring-clojure/ring-defaults))
-- `+code-of-conduct` / `+coc` Add the [contributor covenant](http://contributor-covenant.org/) Code of Conduct
+  [ring.defaults documentation](https://github.com/ring-clojure/ring-defaults)).
+- `+code-of-conduct` / `+coc` Add the [contributor covenant](http://contributor-covenant.org/) Code of Conduct.
+- `+edge` Use the latest available version of all libraries/plugins. This includes alpha/beta versions, but does not include SNAPSHOT versions.
+- `+bleeding-edge` Like `+edge`, but also use SNAPSHOT versions when available.
 
 Choice of UI library:
 
-- `+vanilla` Don't include Om, use this if you intend to use some other view library
-- `+om-next` Use om.next, instead of legacy Om
-- `+reagent` Use Reagent instead of Om
-- `+re-frame` Use Reagent and re-frame
-- `+rum` Use Rum instead of Om
+- `+vanilla` Don't include Om, use this if you intend to use some other view library.
+- `+om-next` Use om.next, instead of legacy Om.
+- `+reagent` Use Reagent instead of Om.
+- `+re-frame` Use Reagent and re-frame.
+- `+rum` Use Rum instead of Om.
 
 Choice of CSS style:
 
 - `+less` Use [less](https://github.com/montoux/lein-less) for compiling Less CSS files.
-- `+sass` Use SASS for generating CSS
-- `+garden` Use Garden for generating CSS
+- `+sass` Use SASS for generating CSS.
+- `+garden` Use Garden for generating CSS.
 
 ## Local copy
 

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [org.apache.httpcomponents/httpclient "4.5.3"]
                  ;;[re-frame/lein-template "0.2.7-1"]
                  [com.github.plexus/re-frame-template "v0.2.7-1-indent-fix"]
-                 ]
+                 [ancient-clj "0.3.14"]]
 
 
   :profiles {:test {:dependencies [[org.clojure/core.async "0.3.443"]

--- a/repl/ancient.clj
+++ b/repl/ancient.clj
@@ -1,0 +1,53 @@
+(ns repl.ancient)
+
+(require '[ancient-clj.core :as ancient]
+         '[leiningen.new.chestnut :as chestnut])
+
+ancient/default-repositories
+
+(ancient/latest-version-string! 'ancient-clj)
+
+(defn update-dep [dep]
+  (assoc dep 1 (ancient/latest-version-string! dep {:snapshots? false})))
+
+(let [deps (map update-dep chestnut/default-project-deps)
+      plugins (map update-dep chestnut/default-project-plugins)
+      dev-deps (map update-dep chestnut/project-clj-dev-deps)
+      dev-plugins (map update-dep chestnut/project-clj-dev-plugins)
+      optional-deps (reduce #(update %1 %2 update-dep)
+                            chestnut/optional-project-deps
+                            (keys chestnut/optional-project-deps))]
+
+  (print
+   (str "(def default-project-deps '["
+        (chestnut/indent-next 28 (map pr-str deps))
+        "])"
+        "\n\n"
+        "(def optional-project-deps '{"
+        (chestnut/indent-next 29 (map #(str (pr-str (first %)) " " (pr-str (second %))) optional-deps))
+        "})"
+        "\n\n"
+        "(def default-project-plugins '["
+        (chestnut/indent-next 31 (map pr-str plugins))
+        "])"
+        "\n\n"
+        "(def project-clj-dev-deps '["
+        (chestnut/indent-next 28 (map pr-str dev-deps))
+        "])"
+        "\n\n"
+        "(def project-clj-dev-plugins '["
+        (chestnut/indent-next 31 (map pr-str dev-plugins))
+        "])"
+        ))
+  )
+
+(def optional-project-deps '{:http-kit   [http-kit "2.2.0"]
+                             :reagent    [reagent "0.6.0"]
+                             :om         [org.omcljs/om "1.0.0-alpha48"]
+                             :om-next    [org.omcljs/om "1.0.0-alpha48"]
+                             :rum        [rum "0.10.8"]
+                             :re-frame   [re-frame "0.9.4"]
+                             :garden     [lambdaisland/garden-watcher "0.3.1"]
+                             :lein-sassc [lein-sassc "0.10.4"]
+                             :lein-auto  [lein-auto "0.1.3"]
+                             :lein-less  [lein-less "1.7.5"]})

--- a/repl/ancient.clj
+++ b/repl/ancient.clj
@@ -24,7 +24,7 @@ ancient/default-repositories
         "])"
         "\n\n"
         "(def optional-project-deps '{"
-        (chestnut/indent-next 29 (map #(str (pr-str (first %)) " " (pr-str (second %))) optional-deps))
+        (chestnut/indent-next 29 (sort (map #(str (pr-str (first %)) " " (pr-str (second %))) optional-deps)))
         "})"
         "\n\n"
         "(def default-project-plugins '["
@@ -37,17 +37,4 @@ ancient/default-repositories
         "\n\n"
         "(def project-clj-dev-plugins '["
         (chestnut/indent-next 31 (map pr-str dev-plugins))
-        "])"
-        ))
-  )
-
-(def optional-project-deps '{:http-kit   [http-kit "2.2.0"]
-                             :reagent    [reagent "0.6.0"]
-                             :om         [org.omcljs/om "1.0.0-alpha48"]
-                             :om-next    [org.omcljs/om "1.0.0-alpha48"]
-                             :rum        [rum "0.10.8"]
-                             :re-frame   [re-frame "0.9.4"]
-                             :garden     [lambdaisland/garden-watcher "0.3.1"]
-                             :lein-sassc [lein-sassc "0.10.4"]
-                             :lein-auto  [lein-auto "0.1.3"]
-                             :lein-less  [lein-less "1.7.5"]})
+        "])")))

--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -4,21 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.671" :scope "provided"]
-                 [com.cognitect/transit-clj "0.8.300"]
-                 [ring "1.6.2"]
-                 [ring/ring-defaults "0.3.1"]
-                 [bk/ring-gzip "0.2.1"]
-                 [radicalzephyr/ring.middleware.logger "0.6.0"]
-                 [compojure "1.6.0"]
-                 [environ "1.1.0"]
-                 [com.stuartsierra/component "0.3.2"]
-                 [org.danielsz/system "0.4.0"]
-                 [org.clojure/tools.namespace "0.2.11"]{{{project-clj-deps}}}]
+  :dependencies [{{{project-clj-deps}}}]
 
-  :plugins [[lein-cljsbuild "1.1.6"]
-            [lein-environ "1.1.0"]{{{project-plugins}}}]
+  :plugins [{{{project-plugins}}}]
 
   :min-lein-version "2.6.1"
 
@@ -109,15 +97,9 @@
   {{/sass?}}
 
   :profiles {:dev
-             {:dependencies [[figwheel "0.5.11"]
-                             [figwheel-sidecar "0.5.11"]
-                             [com.cemerick/piggieback "0.2.2"]
-                             [org.clojure/tools.nrepl "0.2.13"]
-                             [lein-doo "0.1.7"]
-                             [reloaded.repl "0.2.3"]]
+             {:dependencies [{{{project-clj-dev-deps}}}]
 
-              :plugins [[lein-figwheel "0.5.11"]
-                        [lein-doo "0.1.7"]]
+              :plugins [{{{project-clj-dev-plugins}}}]
 
               :source-paths ["dev"]
               :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}


### PR DESCRIPTION
Add `+edge` and `+bleeding-edge` options, powered by `ancient-clj`, which automatically make sure all libraries are at their latest version.

`+bleeding-edge` includes SNAPSHOT versions, `+edge` does not.

Also includes some helper code for updating all dependencies used inside Chestnut, so it's easier to keep the template up to date.