### PR TITLE
Upgrade ClojureScript, Om, Reagent, lein-cljsbuild, Figwheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 /.repl
 /out
 resources/public
+.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### master (unreleased)
 
 - Add `+edge` and `+bleeding-edge` options for automatically using the latest version of dependencies.
+- Upgrade ClojureScript, Om, Reagent, lein-cljsbuild, Figwheel
 
 ### [0.15.2] - 2017-07-30
 

--- a/repl/ancient.clj
+++ b/repl/ancient.clj
@@ -1,11 +1,11 @@
-(ns repl.ancient)
+(ns repl.ancient
+  (:require [ancient-clj.core :as ancient]
+            [leiningen.new.chestnut :as chestnut]))
 
-(require '[ancient-clj.core :as ancient]
-         '[leiningen.new.chestnut :as chestnut])
+(comment
+  ancient/default-repositories
 
-ancient/default-repositories
-
-(ancient/latest-version-string! 'ancient-clj)
+  (ancient/latest-version-string! 'ancient-clj))
 
 (defn update-dep [dep]
   (assoc dep 1 (ancient/latest-version-string! dep {:snapshots? false})))

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -10,7 +10,7 @@
   (:import java.io.Writer))
 
 (def default-project-deps '[[org.clojure/clojure "1.8.0"]
-                            [org.clojure/clojurescript "1.9.671" :scope "provided"]
+                            [org.clojure/clojurescript "1.9.854" :scope "provided"]
                             [com.cognitect/transit-clj "0.8.300"]
                             [ring "1.6.2"]
                             [ring/ring-defaults "0.3.1"]
@@ -22,28 +22,28 @@
                             [org.danielsz/system "0.4.0"]
                             [org.clojure/tools.namespace "0.2.11"]])
 
-(def optional-project-deps '{:http-kit [http-kit "2.2.0"]
-                             :reagent [reagent "0.6.0"]
-                             :om [org.omcljs/om "1.0.0-alpha48"]
-                             :om-next [org.omcljs/om "1.0.0-alpha48"]
-                             :rum [rum "0.10.8"]
-                             :re-frame [re-frame "0.9.4"]
-                             :garden [lambdaisland/garden-watcher "0.3.1"]
-                             :lein-sassc [lein-sassc "0.10.4"]
+(def optional-project-deps '{:garden [lambdaisland/garden-watcher "0.3.1"]
+                             :http-kit [http-kit "2.2.0"]
                              :lein-auto [lein-auto "0.1.3"]
-                             :lein-less [lein-less "1.7.5"]})
+                             :lein-less [lein-less "1.7.5"]
+                             :lein-sassc [lein-sassc "0.10.4"]
+                             :om [org.omcljs/om "1.0.0-beta1"]
+                             :om-next [org.omcljs/om "1.0.0-beta1"]
+                             :re-frame [re-frame "0.9.4"]
+                             :reagent [reagent "0.7.0"]
+                             :rum [rum "0.10.8"]})
 
-(def default-project-plugins '[[lein-cljsbuild "1.1.6"]
+(def default-project-plugins '[[lein-cljsbuild "1.1.7"]
                                [lein-environ "1.1.0"]])
 
-(def project-clj-dev-deps '[[figwheel "0.5.11"]
-                            [figwheel-sidecar "0.5.11"]
+(def project-clj-dev-deps '[[figwheel "0.5.12"]
+                            [figwheel-sidecar "0.5.12"]
                             [com.cemerick/piggieback "0.2.2"]
                             [org.clojure/tools.nrepl "0.2.13"]
                             [lein-doo "0.1.7"]
                             [reloaded.repl "0.2.3"]])
 
-(def project-clj-dev-plugins '[[lein-figwheel "0.5.11"]
+(def project-clj-dev-plugins '[[lein-figwheel "0.5.12"]
                                [lein-doo "0.1.7"]])
 
 ;; When using `pr`, output quoted forms as 'foo, and not as (quote foo)


### PR DESCRIPTION
First time the ancient repl script is being put to use. The diff is still a bit messy because the ordering in the optional deps changed, they're sorted now so that shouldn't be a problem in the future.

I manually reverted any alpha/beta versions back to their latest stable, except for Om which we had in alpha and is now in beta. This is something we might want to hack into the script to happen automatically.