### PR TITLE
Fix development middleware order

### DIFF
--- a/src/leiningen/new/chestnut/dev/user.clj
+++ b/src/leiningen/new/chestnut/dev/user.clj
@@ -15,7 +15,7 @@
     (assoc ({{project-ns}}.application/app-system config)
            :middleware (new-middleware
                         {:middleware
-                         (conj (:middleware config) [wrap-file "dev-target/public"])})
+                         (vec (concat [[wrap-file "dev-target/public"]] (:middleware config)))})
            :figwheel-system (fw-sys/figwheel-system (fw-config/fetch-config))
            :css-watcher (fw-sys/css-watcher {:watch-paths ["resources/public/css"]}){{{extra-dev-components}}})))
 


### PR DESCRIPTION
We need to wrap-file at its earliest so that subsequent
middleware (eg, wrap-mime) is applied properly to hosted files from
this path.

(Service workers for instance check for a valid mime type on registration.)