### PR TITLE
correct sassc build command

### DIFF
--- a/src/leiningen/new/chestnut/README.md
+++ b/src/leiningen/new/chestnut/README.md
@@ -146,7 +146,7 @@ To compile your SCSS stylesheets to CSS, issue
 
 To automatically recompile when files change, you can use
 
-    lein auto sassc
+    lein auto sassc once
 {{/sass?}}
 
 ## License


### PR DESCRIPTION
This corrects the generated README's shell command for watching scss files.