### PR TITLE
Lein 1.8 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### master (unreleased)
+### [0.15.3] (unreleased)
 
 - Add `+edge` and `+bleeding-edge` options for automatically using the latest version of dependencies.
 - Upgrade ClojureScript, Om, Reagent, lein-cljsbuild, Figwheel
@@ -8,6 +8,7 @@
 - Bring back logging to file, using [clj-logging-config](https://github.com/malcolmsparks/clj-logging-config)
 - Add a help screen (`+help` or when using any unrecognized options)
 - Set `goog.DEBUG` to `false` in the production ClojureScript build
+- Fix lein 1.8 compatability
 
 ### [0.15.2] - 2017-07-30
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject chestnut/lein-template "0.15.2"
+(defproject chestnut/lein-template "0.15.3-SNAPSHOT"
   :description "A Leiningen template for a minimal but complete Clojure/ClojureScript setup."
   :url "https://github.com/plexus/chestnut"
 
@@ -12,7 +12,8 @@
                  [org.apache.httpcomponents/httpclient "4.5.3"]
                  ;;[re-frame/lein-template "0.2.7-1"]
                  [com.github.plexus/re-frame-template "v0.2.7-1-indent-fix"]
-                 [ancient-clj "0.3.14"]]
+                 [lein-ancient "0.6.14"]
+                 [ancient-clj "0.6.14"]]
 
 
   :profiles {:test {:dependencies [[org.clojure/core.async "0.3.443"]

--- a/project.clj
+++ b/project.clj
@@ -12,8 +12,8 @@
                  [org.apache.httpcomponents/httpclient "4.5.3"]
                  ;;[re-frame/lein-template "0.2.7-1"]
                  [com.github.plexus/re-frame-template "v0.2.7-1-indent-fix"]
-                 [lein-ancient "0.6.14"]
-                 [ancient-clj "0.6.14"]]
+                 [ancient-clj "0.6.14"]
+                 [clj-http "3.7.0"]]
 
 
   :profiles {:test {:dependencies [[org.clojure/core.async "0.3.443"]


### PR DESCRIPTION
Bump snapshot version

New project under lein 1.8 throws:
`Could not load template, failed with: java.io.FileNotFoundException:
Could not locate slingshot/slingshot__init.class or
slingshot/slingshot.clj on classpath.,
compiling:(clj_http/client.clj:1:1)`

see https://github.com/xsc/lein-ancient/issues/80