### PR TITLE
Project won't start with Java 9

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -21,6 +21,9 @@
   ;; Use `lein run` if you just want to start a HTTP server, without figwheel
   :main {{{project-ns}}}.application
 
+  ;; Workaround for figwheel Java 9 incompatibility
+  :jvm-opts ["--add-modules" "java.xml.bind"]
+
   ;; nREPL by default starts in the :main namespace, we want to start in `user`
   ;; because that's where our development helper functions like (go) and
   ;; (browser-repl) live.


### PR DESCRIPTION
Applied workaround for figwheel Java 9 incompatibility issue described here: bhauman/lein-figwheel#612