### PR TITLE
Fix Clojureverse link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # chestnut
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/plexus/chestnut?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Clojureverse](https://rawgit.com/clojureverse/clojureverse-assets/master/clojureverse-org-green.svg)](http://clojureverse.org/c/chestnut)
+[![Clojureverse](https://rawgit.com/clojureverse/clojureverse-assets/master/clojureverse-org-green.svg)](https://clojureverse.org/c/projects/chestnut)
 
 [![Clojars Project](http://clojars.org/chestnut/lein-template/latest-version.svg)](http://clojars.org/chestnut/lein-template)
 


### PR DESCRIPTION
I noticed that the Clojureverse link wasn't working. My suspicion is that this changed with a recent re-org over there, and I _think_ this is where the link is meant to point.