### PR TITLE
bidi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ General options:
 - `+help` Show an overview of all recognized options, then exit.
 - `+no-poll` Opt out of usage statistics poll.
 - `+http-kit` Use [HTTP Kit](http://http-kit.org/server.html) instead of Jetty.
+- `+bidi` Use [bidi](https://github.com/juxt/bidi) instead of Compojure.
 - `+site-middleware` Use the `ring.middleware.defaults.site-defaults` middleware (session, CSRF), instead of `ring.middleware.defaults.api-defaults` (see
   [ring.defaults documentation](https://github.com/ring-clojure/ring-defaults)).
 - `+code-of-conduct` / `+coc` Add the [contributor covenant](http://contributor-covenant.org/) Code of Conduct.

--- a/src/leiningen/new/chestnut.clj
+++ b/src/leiningen/new/chestnut.clj
@@ -17,7 +17,6 @@
                             [bk/ring-gzip "0.2.1"]
                             [radicalzephyr/ring.middleware.logger "0.6.0"]
                             [clj-logging-config "1.9.12"]
-                            [compojure "1.6.0"]
                             [environ "1.1.0"]
                             [com.stuartsierra/component "0.3.2"]
                             [org.danielsz/system "0.4.0"]
@@ -25,6 +24,8 @@
 
 (def optional-project-deps '{:garden [lambdaisland/garden-watcher "0.3.1"]
                              :http-kit [http-kit "2.2.0"]
+                             :compojure [compojure "1.6.0"]
+                             :bidi [bidi "2.1.3"]
                              :lein-auto [lein-auto "0.1.3"]
                              :lein-less [lein-less "1.7.5"]
                              :lein-sassc [lein-sassc "0.10.4"]
@@ -77,6 +78,7 @@
 (def options-descriptions
   {"help"            "Show this help information and exit."
    "http-kit"        "Use the http-kit web server, instead of Jetty."
+   "bidi"            "Use bidi for server side routing library instead of compojure."
    "site-middleware" "Use Ring's site-middleware, instead of the api-middleware. (session support)"
    "less"            "Use the LESS CSS pre-processor."
    "sass"            "Use the SASS CSS pre-processor."
@@ -94,6 +96,7 @@
 
 (def all-options
   ["http-kit"
+   "bidi"
    "site-middleware"
    "less"
    "sass"
@@ -114,6 +117,9 @@
   (eval
    `(defn ~(symbol (str opt "?")) [opts#]
       (some #{~(str "--" opt) ~(str "+" opt)} opts#))))
+
+(defn compojure? [opts]
+  (not (bidi? opts)))
 
 (defn om? [opts]
   (and (not (reagent? opts))
@@ -150,6 +156,8 @@
   (update-deps
    (cond-> default-project-deps
      (http-kit? opts) (conj (get optional-project-deps :http-kit))
+     (compojure? opts) (conj (get optional-project-deps :compojure))
+     (bidi? opts)     (conj (get optional-project-deps :bidi))
      (reagent? opts)  (conj (get optional-project-deps :reagent))
      (om? opts)       (conj (get optional-project-deps :om))
      (om-next? opts)  (conj (get optional-project-deps :om-next))
@@ -224,6 +232,9 @@
    ;; TODO: get rid of these, instead use something like :project-clj-extras
    :less?                (less? opts)
    :sass?                (sass? opts)
+
+   :compojure?           (compojure? opts)
+   :bidi?                (bidi? opts)
 
    :extra-dev-components (indent 4 (->> (extra-dev-components name opts)
                                         (map pr-str)

--- a/src/leiningen/new/chestnut/src/clj/chestnut/application.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/application.clj
@@ -12,7 +12,7 @@
   (component/system-map
    :routes     (new-endpoint home-routes)
    :middleware (new-middleware {:middleware (:middleware config)})
-   :handler    (-> (new-handler)
+   :handler    (-> {{#compojure?}}(new-handler){{/compojure?}}{{#bidi?}}(new-handler :router :bidi){{/bidi?}}
                    (component/using [:routes :middleware]))
    :http       (-> (new-web-server (:http-port config))
                    (component/using [:handler]))

--- a/src/leiningen/new/chestnut/src/clj/chestnut/routes.clj
+++ b/src/leiningen/new/chestnut/src/clj/chestnut/routes.clj
@@ -1,8 +1,16 @@
 (ns {{project-ns}}.routes
   (:require [clojure.java.io :as io]
+{{#compojure?}}
             [compojure.core :refer [ANY GET PUT POST DELETE routes]]
             [compojure.route :refer [resources]]
+{{/compojure?}}
+{{#bidi?}}
+            [ring.util.response :refer [resource-response]]
+            [bidi.bidi :as bidi]
+            [bidi.ring :refer [resources]]
+{{/bidi?}}
             [ring.util.response :refer [response]]))
+{{#compojure?}}
 
 (defn home-routes [endpoint]
   (routes
@@ -13,3 +21,17 @@
          response
          (assoc :headers {"Content-Type" "text/html; charset=utf-8"})))
    (resources "/")))
+{{/compojure?}}
+{{#bidi?}}
+
+(defn index-handler [req]
+  (assoc (resource-response "index.html" {:root "public"})
+         :headers {"Content-Type" "text/html; charset=UTF-8"}))
+
+(def routes ["/" {""    {:get index-handler}
+                  "css" {:get (resources {:prefix "public/css/"})}
+                  "js"  {:get (resources {:prefix "public/js/"})}}])
+
+(defn home-routes [endpoint]
+  routes)
+{{/bidi?}}


### PR DESCRIPTION
I prefer to use `bidi` for server side routing library rather than `Compojure`.
So I tried to support this as command line option `+bidi`.
When `+bidi` not specified, generates files for `Compojure`.

I prefer to use `bidi` for server side routing libraries instead of` Compojure`.
So I tried supporting it as a command line option `+ bidi`.
If `+ bidi` is not specified, it creates conventional` Compojure` files.