### PR TITLE
cider-cljs-lein-repl is deprecated.

### DIFF
--- a/src/leiningen/new/chestnut/.dir-locals.el
+++ b/src/leiningen/new/chestnut/.dir-locals.el
@@ -1,3 +1,3 @@
 ((nil . ((cider-refresh-before-fn . "reloaded.repl/suspend")
          (cider-refresh-after-fn  . "reloaded.repl/resume")
-         (cider-cljs-lein-repl    . "(do (user/go) (user/cljs-repl))"))))
+         (cider-default-cljs-repl . "(do (user/go) (user/cljs-repl))"))))


### PR DESCRIPTION
In the latest version of CIDER, `cider-cljs-lein-repl` is deprecated.
Emacs says:

     cider-cljs-lein-repl is obsolete (since 0.17); use ‘cider-default-cljs-repl’ instead

This PR fix it.