### PR TITLE
Update CIDER vars in .dir-locals.el

### DIFF
--- a/src/leiningen/new/chestnut/.dir-locals.el
+++ b/src/leiningen/new/chestnut/.dir-locals.el
@@ -1,3 +1,3 @@
-((nil . ((cider-refresh-before-fn . "reloaded.repl/suspend")
-         (cider-refresh-after-fn  . "reloaded.repl/resume")
+((nil . ((cider-ns-refresh-before-fn . "reloaded.repl/suspend")
+         (cider-ns-refresh-after-fn  . "reloaded.repl/resume")
          (cider-cljs-lein-repl    . "(do (user/go) (user/cljs-repl))"))))


### PR DESCRIPTION
The vars `cider-refresh-before-fn` and `cider-refresh-after-fn` are obsolete since 0.18: https://github.com/clojure-emacs/cider/blob/master/cider-ns.el#L104
It seems like using those variables should still work, but before these changes, `cider-ns-refresh` only printed "Don't know how to make a localized variable an alias” (see https://stackoverflow.com/questions/52191455/calling-cider-refresh-shows-dont-know-how-to-make-a-localized-variable-an-alia)
After these changes (and an emacs restart), `cider-ns-refresh` worked again.