### PR TITLE
Increase REPL timeout to 5 minutes

### DIFF
--- a/src/leiningen/new/chestnut/project.clj
+++ b/src/leiningen/new/chestnut/project.clj
@@ -24,7 +24,7 @@
   ;; nREPL by default starts in the :main namespace, we want to start in `user`
   ;; because that's where our development helper functions like (go) and
   ;; (browser-repl) live.
-  :repl-options {:init-ns user}
+  :repl-options {:timeout 300000 :init-ns user}
 
   :cljsbuild {:builds
               [{:id "app"


### PR DESCRIPTION
Starting a REPL on a new project times out (issue #243). This increases
the timeout for starting the REPL to 5 minutes.